### PR TITLE
Avoid Jinja in the playground runtime

### DIFF
--- a/docs/assets/playground/THIRD_PARTY_LICENSES.txt
+++ b/docs/assets/playground/THIRD_PARTY_LICENSES.txt
@@ -45,20 +45,33 @@ Comlink is distributed under the Apache License 2.0.
 ## Python packages
 
 The playground loads `micropip` from the Pyodide package index, then installs
-Python packages from PyPI with `micropip` inside Pyodide. The primary packages
-are:
+Python packages from PyPI with `micropip` inside Pyodide.
+
+### Current and compiled-template releases
+
+These packages are installed for the current playground and releases with
+compiled built-in templates:
 
 - `datamodel-code-generator`
 - `genson`
 - `graphql-core`
 - `inflect`
-- `jinja2`
 - `pydantic`
 - `pyyaml`
 
 The generator package is installed without its declared transitive dependencies
 so the browser runtime can use the builtin formatter without loading black or
-isort. Runtime dependencies needed by the playground are installed explicitly.
-The static playground shell is generated at build time with `tdom`. Current
-runtime assets do not install `tdom`; older version assets that still use
-`app.py` may install it for compatibility.
+isort. Current runtime assets render built-in templates without Jinja2 or
+MarkupSafe, and do not support custom Jinja2 templates. Runtime dependencies
+needed by the playground are installed explicitly.
+
+### Legacy releases without compiled templates
+
+The version selector installs these packages only for releases that need Jinja
+to render their built-in templates:
+
+- `jinja2`
+- `markupsafe`
+
+The static playground shell is generated at build time with `tdom`. Older
+version assets that still use `app.py` may install it for compatibility.

--- a/docs/assets/playground/main.js
+++ b/docs/assets/playground/main.js
@@ -77,6 +77,13 @@ function normalizeInstall(install, assetBaseUrl) {
   return null;
 }
 
+function normalizeRuntimePackages(runtimePackages) {
+  if (!Array.isArray(runtimePackages)) {
+    return [];
+  }
+  return runtimePackages.map((runtimePackage) => String(runtimePackage).trim()).filter(Boolean);
+}
+
 function normalizePlaygroundVersion(entry) {
   const id = String(entry?.id || "").trim();
   if (!id) {
@@ -96,6 +103,7 @@ function normalizePlaygroundVersion(entry) {
     ),
     appUrl: absoluteUrl(entry.app || entry.app_url || defaultApp, assetBaseUrl),
     install: normalizeInstall(entry.install, assetBaseUrl),
+    runtimePackages: normalizeRuntimePackages(entry.runtime_packages || entry.runtimePackages),
   };
 }
 

--- a/docs/assets/playground/worker.js
+++ b/docs/assets/playground/worker.js
@@ -5,7 +5,6 @@ const PYODIDE_VERSION = "314.0.0";
 const PYODIDE_INDEX = "https://cdn.jsdelivr.net/pyodide/v314.0.0/full/";
 const STANDARD_RUNTIME_PACKAGES = [
   "inflect>=4.1,<8",
-  "jinja2>=2.10.1,<4",
   "pydantic>=2.12,<3",
   "pyyaml>=6.0.1",
 ];
@@ -47,6 +46,7 @@ function withDefaultVersionConfig(versionConfig = {}) {
     metadataUrl: config.metadataUrl || new URL("codegen-ui-metadata.json", assetBaseUrl).toString(),
     appUrl: config.appUrl || new URL("runtime.py", assetBaseUrl).toString(),
     install: config.install || null,
+    runtimePackages: Array.isArray(config.runtimePackages) ? config.runtimePackages : [],
   };
 }
 
@@ -123,7 +123,7 @@ async function initPyodide(versionConfig) {
 
   await installPythonPackages(
     pyodide,
-    [...STANDARD_RUNTIME_PACKAGES, ...packagesForRuntimeApp(activeVersion)],
+    [...STANDARD_RUNTIME_PACKAGES, ...activeVersion.runtimePackages, ...packagesForRuntimeApp(activeVersion)],
     "Installing generator runtime dependencies...",
   );
 

--- a/scripts/build_playground_assets.py
+++ b/scripts/build_playground_assets.py
@@ -66,6 +66,7 @@ UI_PROVIDED_OPTIONS = {
 # (network access, optional extras, and local Python modules). Everything else is classified
 # dynamically from the GenerateConfig schema by _option_support() below.
 BROWSER_UNAVAILABLE_OPTIONS = {
+    "custom_template_dir": "Custom Jinja2 templates are not available in the browser playground.",
     "url": "Remote input URLs are not fetched by the browser playground.",
     "input_model": "Python module imports are not available in the browser playground.",
     "allow_remote_refs": "Resolving remote $refs needs network access.",

--- a/scripts/build_playground_release_versions.py
+++ b/scripts/build_playground_release_versions.py
@@ -10,6 +10,8 @@ import sys
 from typing import Any
 
 PLAYGROUND_RUNTIME_PATH = "docs/assets/playground/runtime.py"
+COMPILED_TEMPLATE_REGISTRY_PATH = "src/datamodel_code_generator/model/_compiled_templates/registry.py"
+LEGACY_RUNTIME_PACKAGES = ("jinja2>=2.10.1,<4",)
 
 
 def run_gh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -40,13 +42,13 @@ def _release_tags(repo: str, limit: int) -> list[str]:
     return [tag for tag in tags if isinstance(tag, str) and tag]
 
 
-def _has_playground_runtime(repo: str, tag: str) -> bool:
+def _has_file(repo: str, tag: str, path: str) -> bool:
     result = run_gh(
         [
             "api",
             "--method",
             "GET",
-            f"repos/{repo}/contents/{PLAYGROUND_RUNTIME_PATH}",
+            f"repos/{repo}/contents/{path}",
             "-f",
             f"ref={tag}",
         ],
@@ -55,8 +57,16 @@ def _has_playground_runtime(repo: str, tag: str) -> bool:
     return result.returncode == 0
 
 
-def _release_version(tag: str) -> dict[str, Any]:
-    return {
+def _has_playground_runtime(repo: str, tag: str) -> bool:
+    return _has_file(repo, tag, PLAYGROUND_RUNTIME_PATH)
+
+
+def _uses_compiled_templates(repo: str, tag: str) -> bool:
+    return _has_file(repo, tag, COMPILED_TEMPLATE_REGISTRY_PATH)
+
+
+def _release_version(tag: str, *, uses_compiled_templates: bool) -> dict[str, Any]:
+    version = {
         "id": tag,
         "label": tag,
         "kind": "release",
@@ -67,6 +77,9 @@ def _release_version(tag: str) -> dict[str, Any]:
         },
         "app": "runtime.py",
     }
+    if not uses_compiled_templates:
+        version["runtime_packages"] = list(LEGACY_RUNTIME_PACKAGES)
+    return version
 
 
 def _build_release_versions(repo: str, limit: int) -> list[dict[str, Any]]:
@@ -74,7 +87,7 @@ def _build_release_versions(repo: str, limit: int) -> list[dict[str, Any]]:
     for tag in _release_tags(repo, limit):
         if not _has_playground_runtime(repo, tag):
             continue
-        versions.append(_release_version(tag))
+        versions.append(_release_version(tag, uses_compiled_templates=_uses_compiled_templates(repo, tag)))
     return versions
 
 

--- a/tests/data/expected/main/cli_fast_paths/playground_builtin_templates.txt
+++ b/tests/data/expected/main/cli_fast_paths/playground_builtin_templates.txt
@@ -1,0 +1,7 @@
+{
+  "custom_template_browser_supported": false,
+  "custom_template_ignored": true,
+  "generated_person": true,
+  "imported_jinja2": false,
+  "imported_markupsafe": false
+}

--- a/tests/data/expected/playground_assets/template_runtime_contract.txt
+++ b/tests/data/expected/playground_assets/template_runtime_contract.txt
@@ -1,0 +1,17 @@
+{
+  "custom_template_option": {
+    "browser_supported": false,
+    "unsupported_reason": "Custom Jinja2 templates are not available in the browser playground."
+  },
+  "release_runtime_packages": {
+    "compiled": [],
+    "legacy": [
+      "jinja2>=2.10.1,<4"
+    ]
+  },
+  "worker": {
+    "current_installs_jinja2": false,
+    "merges_version_runtime_packages": true,
+    "standard_packages_declared": true
+  }
+}

--- a/tests/main/test_cli_fast_paths.py
+++ b/tests/main/test_cli_fast_paths.py
@@ -390,6 +390,58 @@ def _run_schema_runtime_validation_helper_probe() -> dict[str, Any]:
     )
 
 
+def _run_playground_builtin_template_probe() -> dict[str, Any]:
+    return _run_probe(
+        textwrap.dedent(
+            """
+            import importlib.abc
+            import importlib.util
+            import json
+            import sys
+            from pathlib import Path
+
+            from scripts.build_playground_assets import build_metadata
+
+            class BlockBrowserTemplatePackages(importlib.abc.MetaPathFinder):
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname.partition(".")[0] in {"jinja2", "markupsafe"}:
+                        raise ModuleNotFoundError(f"{fullname} is not installed in the browser runtime")
+                    return None
+
+            sys.meta_path.insert(0, BlockBrowserTemplatePackages())
+            runtime_path = Path("docs/assets/playground/runtime.py")
+            spec = importlib.util.spec_from_file_location("playground_runtime", runtime_path)
+            if spec is None or spec.loader is None:
+                raise RuntimeError("Could not load playground runtime")
+            runtime = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(runtime)
+
+            metadata = build_metadata()
+            runtime.set_ui_metadata(json.dumps(metadata))
+            result = json.loads(
+                runtime.generate_in_browser(
+                    runtime.sample_schema("jsonschema"),
+                    "jsonschema",
+                    json.dumps({"custom_template_dir": "templates"}),
+                )
+            )
+            custom_template = next(option for option in metadata["options"] if option["dest"] == "custom_template_dir")
+            cli_options = runtime.build_cli_options(
+                json.dumps({"custom_template_dir": "templates"}),
+                "jsonschema",
+            )
+            print(json.dumps({
+                "custom_template_browser_supported": custom_template["browser_supported"],
+                "custom_template_ignored": "--custom-template-dir" not in cli_options,
+                "generated_person": result["ok"] and "class Pet(BaseModel):" in result["output"],
+                "imported_jinja2": "jinja2" in sys.modules,
+                "imported_markupsafe": "markupsafe" in sys.modules,
+            }, indent=2, sort_keys=True))
+            """
+        )
+    )
+
+
 def _run_input_model_type_transport_probe() -> dict[str, Any]:
     return _run_probe(
         textwrap.dedent(
@@ -760,6 +812,17 @@ def test_schema_runtime_validation_module_helper_skips_jinja_in_a_fresh_process(
     assert_output(
         f"{json.dumps(result, indent=2, sort_keys=True)}\n",
         ROOT / "tests/data/expected/main/cli_fast_paths/schema_runtime_validation_helper.txt",
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="The Playground runtime targets Pyodide Python 3.14")
+def test_playground_builtin_generation_skips_jinja_and_custom_templates() -> None:
+    """The browser runtime uses compiled templates and filters custom template input."""
+    result = _run_playground_builtin_template_probe()
+
+    assert_output(
+        f"{json.dumps(result, indent=2, sort_keys=True)}\n",
+        ROOT / "tests/data/expected/main/cli_fast_paths/playground_builtin_templates.txt",
     )
 
 

--- a/tests/test_build_playground_assets_script.py
+++ b/tests/test_build_playground_assets_script.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from typing import Any, cast
 
 from datamodel_code_generator.arguments import arg_parser
-from scripts import build_playground_assets
+from scripts import build_playground_assets, build_playground_release_versions
 from tests.conftest import assert_output
 
 EXPECTED_PLAYGROUND_ASSETS_PATH = Path(__file__).resolve().parent / "data" / "expected" / "playground_assets"
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_option_metadata_docs_urls() -> None:
@@ -25,6 +26,42 @@ def test_option_metadata_docs_urls() -> None:
     assert_output(
         json.dumps(output, indent=2, sort_keys=True) + "\n",
         EXPECTED_PLAYGROUND_ASSETS_PATH / "option_docs_urls.txt",
+    )
+
+
+def test_playground_template_runtime_contract() -> None:
+    """Current builds skip Jinja while older releases retain their runtime dependency."""
+    metadata = build_playground_assets.build_metadata()
+    custom_template_option = next(option for option in metadata["options"] if option["dest"] == "custom_template_dir")
+    worker_source = (ROOT / "docs" / "assets" / "playground" / "worker.js").read_text(encoding="utf-8")
+    standard_packages_marker = "const STANDARD_RUNTIME_PACKAGES = ["
+    standard_packages = worker_source.partition(standard_packages_marker)[2].partition("];")[0]
+    output = {
+        "custom_template_option": {
+            "browser_supported": custom_template_option["browser_supported"],
+            "unsupported_reason": custom_template_option["unsupported_reason"],
+        },
+        "release_runtime_packages": {
+            "compiled": build_playground_release_versions._release_version("v9.9.9", uses_compiled_templates=True).get(
+                "runtime_packages", []
+            ),
+            "legacy": build_playground_release_versions._release_version("v0.0.1", uses_compiled_templates=False).get(
+                "runtime_packages", []
+            ),
+        },
+        "worker": {
+            "current_installs_jinja2": "jinja2" in standard_packages,
+            "standard_packages_declared": standard_packages_marker in worker_source,
+            "merges_version_runtime_packages": (
+                "[...STANDARD_RUNTIME_PACKAGES, ...activeVersion.runtimePackages, "
+                "...packagesForRuntimeApp(activeVersion)]" in worker_source
+            ),
+        },
+    }
+
+    assert_output(
+        json.dumps(output, indent=2, sort_keys=True) + "\n",
+        EXPECTED_PLAYGROUND_ASSETS_PATH / "template_runtime_contract.txt",
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser playground generation when optional template dependencies are unavailable.
  - Clarified that custom Jinja2 templates aren’t supported in the browser playground.
  - Added compatibility handling for releases requiring legacy runtime packages.
  - Improved runtime package selection for releases with or without compiled templates.

- **Tests**
  - Added regression coverage for browser playground output, template behavior, and runtime-package selection.
  - Verified worker runtime packages merge correctly across supported release configurations.
  - Confirmed expected model output when template dependencies are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->