### PR TITLE
Fix batch watch flakes on Windows and macOS

### DIFF
--- a/src/datamodel_code_generator/_publication.py
+++ b/src/datamodel_code_generator/_publication.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import stat
 import tempfile
+import time
 from contextlib import suppress
 from pathlib import Path
 from secrets import token_hex
@@ -26,8 +27,26 @@ if TYPE_CHECKING:
 # binds its Windows accessors at import time, so patching os does not exercise
 # path-based fallback operations consistently.
 _unlink = os.unlink
-_replace = os.replace
 _rmdir = os.rmdir
+
+_REPLACE_ATTEMPTS = 10
+_REPLACE_RETRY_DELAY_SECONDS = 0.05
+# ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION: Windows refuses to replace a target another
+# process (a reader, an indexer) briefly holds open, so the swap is retried before giving up.
+_TRANSIENT_REPLACE_WINERRORS = frozenset({5, 32})
+
+
+def _replace(src: str | Path, dst: str | Path, *, src_dir_fd: int | None = None, dst_dir_fd: int | None = None) -> None:
+    for _attempt in range(_REPLACE_ATTEMPTS - 1):
+        try:
+            os.replace(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+        except PermissionError as exc:
+            if getattr(exc, "winerror", None) not in _TRANSIENT_REPLACE_WINERRORS:
+                raise
+            time.sleep(_REPLACE_RETRY_DELAY_SECONDS)
+        else:
+            return
+    os.replace(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
 
 class PublicationAnchor(NamedTuple):

--- a/tests/main/test_main_watch.py
+++ b/tests/main/test_main_watch.py
@@ -300,6 +300,12 @@ def _write_watch_cli_input_and_wait(
     _wait_for_watch_cli(process, stdout_lines, stderr_lines, condition_after_write, description)
 
 
+def _replace_watch_input(path: Path, content: str) -> None:
+    update = path.with_name(f"{path.stem}-update{path.suffix}")
+    update.write_text(content, encoding="utf-8")
+    update.replace(path)
+
+
 def _lines_contain(lines: list[str], expected_text: str) -> bool:
     return any(expected_text in line for line in lines)
 
@@ -3490,8 +3496,8 @@ def test_batch_watch_nested_dependency_reruns_full_batch_without_output_loop(tmp
         assert_output(
             second_metadata.read_text(encoding="utf-8"), PROJECT_ROOT / "tests/data/expected/main_kr/jobs/stale.py"
         )
-        child_file.write_text(
-            (WATCH_DATA_PATH / "nested_ref/child_changed.json").read_text(encoding="utf-8"), encoding="utf-8"
+        _replace_watch_input(
+            child_file, (WATCH_DATA_PATH / "nested_ref/child_changed.json").read_text(encoding="utf-8")
         )
         _wait_for_watch_cli(
             process,

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -1,0 +1,78 @@
+"""Tests for the atomic publication seams."""
+
+from __future__ import annotations
+
+import errno
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from datamodel_code_generator import _publication as publication_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+def _transient_replace_error(winerror: int) -> PermissionError:
+    error = PermissionError(errno.EACCES, "Access is denied")
+    error.winerror = winerror
+    return error
+
+
+@pytest.mark.allow_direct_assert
+@pytest.mark.parametrize("winerror", [5, 32], ids=["access_denied", "sharing_violation"])
+def test_publish_staged_files_retries_transient_windows_replace_error(
+    tmp_path: Path, mocker: MockerFixture, winerror: int
+) -> None:
+    """A target another process briefly holds open on Windows is swapped in once the handle is released."""
+    staged = tmp_path / "staged.py"
+    staged.write_text("generated\n", encoding="utf-8")
+    target = tmp_path / "target.py"
+    replace = mocker.patch(
+        "os.replace", wraps=os.replace, side_effect=[_transient_replace_error(winerror), mocker.DEFAULT]
+    )
+    sleep = mocker.patch("time.sleep")
+
+    publication_module.publish_staged_files([(staged, target)])
+
+    assert target.read_text(encoding="utf-8") == "generated\n"
+    assert replace.call_count == 2
+    sleep.assert_called_once_with(0.05)
+
+
+@pytest.mark.allow_direct_assert
+def test_publish_staged_files_gives_up_after_repeated_transient_replace_errors(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """A target that stays locked is reported after a bounded number of attempts."""
+    staged = tmp_path / "staged.py"
+    staged.write_text("generated\n", encoding="utf-8")
+    target = tmp_path / "target.py"
+    replace = mocker.patch("os.replace", side_effect=_transient_replace_error(5))
+    sleep = mocker.patch("time.sleep")
+
+    with pytest.raises(PermissionError, match="Access is denied"):
+        publication_module.publish_staged_files([(staged, target)])
+
+    assert replace.call_count == 10
+    assert sleep.call_count == 9
+    assert not target.exists()
+
+
+@pytest.mark.allow_direct_assert
+def test_publish_staged_files_does_not_retry_other_permission_errors(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Permission errors that are not Windows sharing conflicts fail immediately."""
+    staged = tmp_path / "staged.py"
+    staged.write_text("generated\n", encoding="utf-8")
+    target = tmp_path / "target.py"
+    replace = mocker.patch("os.replace", side_effect=PermissionError(errno.EPERM, "Operation not permitted"))
+    sleep = mocker.patch("time.sleep")
+
+    with pytest.raises(PermissionError, match="Operation not permitted"):
+        publication_module.publish_staged_files([(staged, target)])
+
+    replace.assert_called_once()
+    sleep.assert_not_called()


### PR DESCRIPTION
`test_batch_watch_nested_dependency_reruns_full_batch_without_output_loop` fails intermittently in two ways: on Windows the batch publication dies with `[WinError 5] Access is denied` on `os.replace(... first.py)` because the test (or an indexer) briefly holds the target open while the swap runs (https://github.com/koxudaxi/datamodel-code-generator/actions/runs/31701983421/job/94453093852), and on macOS the polling watcher observed the non-atomic `child.json` rewrite as two mtime changes and ran the batch twice, tripping the `done=1` cycle count (https://github.com/koxudaxi/datamodel-code-generator/actions/runs/31757891896/job/94637621310). `_publication._replace` now retries `os.replace` up to ten times at 50 ms on `ERROR_ACCESS_DENIED`/`ERROR_SHARING_VIOLATION` before giving up (other permission errors still fail immediately, covered in `tests/test_publication.py`), and the watch test swaps the changed `child.json` in with a temp file plus `replace`, the same atomic update the neighbouring watch tests already use, so the watcher sees exactly one change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when publishing generated files on Windows by retrying temporary sharing or access conflicts.
  - Preserved immediate failure for unrelated permission errors.
  - Ensured file replacement stops cleanly after repeated transient failures.

- **Tests**
  - Added coverage for successful retries, retry exhaustion, and non-retryable permission errors.
  - Updated watch-mode testing to validate replacement-based file updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->