### PR TITLE
Ignore black and isort updates in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,9 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  ignore:
+  - dependency-name: black
+  - dependency-name: isort
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates will no longer be proposed for the Black and isort tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->