### PR TITLE
Improve release benchmark charts

### DIFF
--- a/.github/workflows/release-benchmarks.yaml
+++ b/.github/workflows/release-benchmarks.yaml
@@ -1,6 +1,10 @@
 name: Release Benchmarks
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - docs/data/release-benchmarks.json
   pull_request:
     types: [labeled]
   workflow_run:
@@ -30,8 +34,10 @@ on:
         default: "3.14.2"
 
 concurrency:
-  group: release-benchmarks-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
-  cancel-in-progress: false
+  # Coalesce redundant main-only measurements, while retaining release,
+  # backfill, and pull-request runs in independent groups.
+  group: release-benchmarks-${{ github.event_name == 'push' && 'main' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:
   contents: read
@@ -42,6 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: >-
       ${{
+        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' &&
@@ -57,6 +64,7 @@ jobs:
     outputs:
       versions_json: ${{ steps.versions.outputs.versions_json }}
       versions: ${{ steps.versions.outputs.versions }}
+      main_sha: ${{ steps.main.outputs.sha }}
     env:
       BENCHMARK_PYTHON_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.14.2' }}
       BENCHMARK_HISTORY_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.history_days || '365' }}
@@ -68,6 +76,16 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+      - name: Resolve current main revision
+        id: main
+        run: |
+          set -euo pipefail
+          main_sha="$(git ls-remote "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" refs/heads/main | awk 'NR == 1 { print $1 }')"
+          if ! [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the current main revision" >&2
+            exit 1
+          fi
+          echo "sha=$main_sha" >> "$GITHUB_OUTPUT"
       - name: Resolve release versions
         id: versions
         env:
@@ -78,24 +96,30 @@ jobs:
         run: |
           set -euo pipefail
           versions="$INPUT_VERSIONS"
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            versions="$WORKFLOW_TAG"
-            case "$versions" in
-              refs/tags/*) versions="${versions#refs/tags/}" ;;
-              v[0-9]* | [0-9]*) ;;
-              *) versions="" ;;
-            esac
-            if [ -z "$versions" ] && [ -n "$WORKFLOW_SHA" ]; then
-              git fetch --tags --force --depth=1 origin '+refs/tags/*:refs/tags/*'
-              versions="$(git tag --points-at "$WORKFLOW_SHA" | sort -V | tail -n 1)"
-            fi
-            if [ -z "$versions" ]; then
-              echo "Could not determine release tag for Publish workflow run $WORKFLOW_SHA" >&2
-              exit 1
-            fi
-          fi
+          case "$EVENT_NAME" in
+            push)
+              versions="main"
+              ;;
+            workflow_run)
+              versions="$WORKFLOW_TAG"
+              case "$versions" in
+                refs/tags/*) versions="${versions#refs/tags/}" ;;
+                v[0-9]* | [0-9]*) ;;
+                *) versions="" ;;
+              esac
+              if [ -z "$versions" ] && [ -n "$WORKFLOW_SHA" ]; then
+                git fetch --tags --force --depth=1 origin '+refs/tags/*:refs/tags/*'
+                versions="$(git tag --points-at "$WORKFLOW_SHA" | sort -V | tail -n 1)"
+              fi
+              if [ -z "$versions" ]; then
+                echo "Could not determine release tag for Publish workflow run $WORKFLOW_SHA" >&2
+                exit 1
+              fi
+              ;;
+          esac
           python scripts/select_release_benchmark_versions.py \
             --versions "$versions" \
+            --include-main \
             --history-days "$BENCHMARK_HISTORY_DAYS" \
             --limit "$BENCHMARK_LIMIT" \
             --output .benchmarks/release-benchmark-selection.json
@@ -120,6 +144,7 @@ jobs:
       BENCHMARK_PYTHON_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.14.2' }}
       BENCHMARK_RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || (github.event_name == 'pull_request' && '3' || '7') }}
       OS: ubuntu-24.04
+      BENCHMARK_MAIN_REF: ${{ needs.resolve.outputs.main_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -135,6 +160,7 @@ jobs:
         run: >-
           python scripts/collect_release_benchmarks.py
           --versions "$BENCHMARK_VERSION"
+          --main-ref "$BENCHMARK_MAIN_REF"
           --runs "$BENCHMARK_RUNS"
           --output ".benchmarks/fragments/release-benchmark-${BENCHMARK_VERSION}.json"
       - name: Upload benchmark fragment
@@ -190,6 +216,7 @@ jobs:
       ${{
         needs.build.result == 'success' &&
         (
+          github.event_name == 'push' ||
           github.event_name == 'workflow_run' ||
           (
             github.event_name == 'workflow_dispatch' &&
@@ -199,6 +226,10 @@ jobs:
         github.repository == 'koxudaxi/datamodel-code-generator'
       }}
     runs-on: ubuntu-24.04
+    concurrency:
+      # Keep every release/backfill update while serializing the shared data branch.
+      group: release-benchmark-data
+      queue: max
     outputs:
       changed: ${{ steps.pr.outputs.changed }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
@@ -231,6 +262,7 @@ jobs:
           )"
           if [ -n "$versions" ] && python scripts/select_release_benchmark_versions.py \
               --versions "$versions" \
+              --include-main \
               --output .benchmarks/update/release-benchmark-selection-refresh.json; then
             :
           else
@@ -256,28 +288,34 @@ jobs:
             koxudaxi/datamodel-code-generator) ;;
             *) echo "Refusing to push release benchmark docs to $TARGET_REPO" >&2; exit 1 ;;
           esac
-          sync_branch="$(
-            python - <<'PY'
-          import hashlib
-          import json
-          import re
-          from pathlib import Path
-
-          payload = json.loads(Path(".benchmarks/update/release-benchmark-selection-refresh.json").read_text())
-          raw = "-".join(str(version) for version in payload.get("selected_versions", []) if version) or "data"
-          safe = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-") or "data"
-          if len(safe) > 80:
-              digest = hashlib.sha256(raw.encode()).hexdigest()[:12]
-              safe = f"{safe[:60].rstrip('-')}-{digest}"
-          print(f"docs/release-benchmark-{safe}")
-          PY
-          )"
-
+          sync_branch="docs/release-benchmark-data"
+          remote_url="https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git"
+          remote_sha="$(git ls-remote --heads "$remote_url" "$sync_branch" | awk '{print $1}')"
           git fetch origin main
-          git reset --hard origin/main
+          current_main_sha="$(git rev-parse origin/main)"
+          git checkout -B "$sync_branch" origin/main
+          if [ -n "$remote_sha" ]; then
+            git fetch "$remote_url" \
+              "refs/heads/$sync_branch:refs/remotes/release-benchmark/$sync_branch"
+            pending_changes="$(
+              git diff --name-only "origin/main...refs/remotes/release-benchmark/$sync_branch"
+            )"
+            case "$pending_changes" in
+              "" | docs/data/release-benchmarks.json) ;;
+              *) echo "Refusing pending benchmark branch with unexpected changes" >&2; exit 1 ;;
+            esac
+            pending_data="$RUNNER_TEMP/release-benchmark-pending.json"
+            git show "refs/remotes/release-benchmark/$sync_branch:docs/data/release-benchmarks.json" > "$pending_data"
+            python scripts/update_release_benchmark_history.py \
+              --base-data docs/data/release-benchmarks.json \
+              --incoming-data "$pending_data" \
+              --current-main-sha "$current_main_sha" \
+              --output docs/data/release-benchmarks.json
+          fi
           python scripts/update_release_benchmark_history.py \
             --incoming-data .benchmarks/update/release-benchmarks.json \
             --selection .benchmarks/update/release-benchmark-selection-refresh.json \
+            --current-main-sha "$current_main_sha" \
             --output docs/data/release-benchmarks.json
           git add docs/data/release-benchmarks.json
           if git diff --cached --quiet; then
@@ -286,8 +324,6 @@ jobs:
           fi
           git commit -m "docs: update release benchmark data"
 
-          remote_url="https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git"
-          remote_sha="$(git ls-remote --heads "$remote_url" "$sync_branch" | awk '{print $1}')"
           if [ -n "$remote_sha" ]; then
             git push --force-with-lease="refs/heads/${sync_branch}:${remote_sha}" \
               "$remote_url" \
@@ -308,10 +344,6 @@ jobs:
           )"
 
           if [ -n "$existing_pr" ]; then
-            gh pr edit "$existing_pr" \
-              --repo "$TARGET_REPO" \
-              --title "Update release benchmark data" \
-              --body ""
             pr_number="$existing_pr"
           else
             pr_url="$(

--- a/docs/assets/benchmarks/release-benchmarks.css
+++ b/docs/assets/benchmarks/release-benchmarks.css
@@ -27,6 +27,53 @@
   height: 420px;
 }
 
+.release-benchmark-chart__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.72rem;
+}
+
+.release-benchmark-chart__controls-label {
+  color: var(--md-default-fg-color--light, #6b7280);
+  font-weight: 700;
+}
+
+.release-benchmark-chart__range-button {
+  min-height: 1.85rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--md-default-fg-color--lightest, #d1d5db);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--md-default-fg-color, #111827);
+  cursor: pointer;
+  font: inherit;
+}
+
+.release-benchmark-chart__range-button[aria-pressed="true"] {
+  border-color: var(--md-accent-fg-color, #0288d1);
+  background: var(--md-accent-fg-color, #0288d1);
+  color: var(--md-primary-bg-color, #ffffff);
+}
+
+.release-benchmark-chart__range-button:focus-visible {
+  outline: 2px solid var(--md-accent-fg-color, #0288d1);
+  outline-offset: 2px;
+}
+
+.release-benchmark-chart__range-info,
+.release-benchmark-chart__main-snapshot {
+  display: block;
+  color: var(--md-default-fg-color--light, #6b7280);
+  font-size: 0.72rem;
+}
+
+.release-benchmark-chart__main-snapshot {
+  margin-top: 0.15rem;
+}
+
 .release-benchmark-chart__legend {
   display: flex;
   flex-wrap: wrap;
@@ -75,7 +122,7 @@
   font-size: 0.72rem;
   pointer-events: none;
   transform: translate(-50%, calc(-100% - 0.6rem));
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .release-benchmark-version-note {
@@ -91,5 +138,9 @@
 
   .release-benchmark-chart canvas {
     height: 320px;
+  }
+
+  .release-benchmark-chart__controls {
+    gap: 0.3rem;
   }
 }

--- a/docs/assets/benchmarks/release-benchmarks.js
+++ b/docs/assets/benchmarks/release-benchmarks.js
@@ -7,6 +7,14 @@
   const WHOLE_MS_THRESHOLD = 100;
   const TENTH_MS_THRESHOLD = 10;
   const SAME_SPEED_TOLERANCE = 0.005;
+  const DEFAULT_RELEASE_RANGE = "10";
+  const ALL_RELEASES_RANGE = "all";
+  const RELEASE_RANGE_OPTIONS = [
+    { value: "10", label: "Latest 10" },
+    { value: "25", label: "Latest 25" },
+    { value: ALL_RELEASES_RANGE, label: "All releases" },
+  ];
+  const MAIN_VERSION = "main";
   const CASE_ORDER = ["small", "large"];
   const FORMATTERS = [
     { key: "default", label: "black/isort(Default)", color: "#f59e0b" },
@@ -14,10 +22,22 @@
     { key: "ruff", label: "Ruff", color: "#16a34a" },
   ];
 
+  if (typeof document === "undefined") {
+    if (typeof module !== "undefined" && module.exports) {
+      module.exports = Object.freeze({
+        chartSelection,
+        mainSnapshotStatus,
+        mainPanelBounds,
+        DEFAULT_RELEASE_RANGE,
+        RELEASE_RANGE_OPTIONS,
+      });
+    }
+    return;
+  }
+
   const scriptUrl = document.currentScript && document.currentScript.src ? document.currentScript.src : document.baseURI;
   const dataUrl = new URL("../../data/release-benchmarks.json", scriptUrl);
   const notesUrl = new URL("../../data/release-benchmark-notes.json", scriptUrl);
-  const MAIN_VERSION = "main";
   const initializedCharts = new WeakSet();
   const initializedApps = new WeakSet();
   const observedCharts = new WeakSet();
@@ -333,6 +353,116 @@
     return versions.length === 0 ? "" : versions[versions.length - 1];
   }
 
+  function releaseVersions(entries) {
+    const versions = new Set();
+    entries.forEach((entry) => {
+      const version = stringValue(entry.version);
+      if (version && version !== MAIN_VERSION) {
+        versions.add(version);
+      }
+    });
+    return Array.from(versions).sort(compareVersions);
+  }
+
+  function visibleReleaseVersions(versions, range) {
+    const count = Number(range);
+    if (!Number.isInteger(count) || count <= 0 || count >= versions.length) {
+      return versions;
+    }
+    return versions.slice(-count);
+  }
+
+  function chartSelection(entries, range) {
+    const allReleaseVersions = releaseVersions(entries);
+    const versions = visibleReleaseVersions(allReleaseVersions, range);
+    const selectedVersions = versions === allReleaseVersions ? null : new Set(versions);
+    const visibleEntries = selectedVersions
+      ? entries.filter((entry) => entry.version === MAIN_VERSION || selectedVersions.has(entry.version))
+      : entries;
+    const mainEntries = entries.filter((entry) => entry.version === MAIN_VERSION);
+    let timingEntryCount = 0;
+    let maxMs = 0;
+    let hasMain = false;
+    visibleEntries.forEach((entry) => {
+      if (entry.status !== STATUS_OK || typeof entry.median_ms !== "number") {
+        return;
+      }
+      timingEntryCount += 1;
+      maxMs = Math.max(maxMs, entry.median_ms);
+      hasMain ||= entry.version === MAIN_VERSION;
+    });
+    return {
+      allReleaseVersions,
+      versions,
+      visibleEntries,
+      mainEntries,
+      hasMain,
+      timingEntryCount,
+      yMax: maxMs > 0 ? maxMs * 1.15 : 1,
+    };
+  }
+
+  function mainPanelBounds(width, horizontalLabelPadding, hasMain) {
+    if (!hasMain) {
+      return null;
+    }
+    const left = width - Math.min(92, Math.max(72, Math.floor(width * 0.23)));
+    return { left, right: width - 8, plotRight: left - horizontalLabelPadding };
+  }
+
+  function chartRange(container) {
+    const range = container.dataset.releaseBenchmarkSelectedRange;
+    return RELEASE_RANGE_OPTIONS.some((option) => option.value === range) ? range : DEFAULT_RELEASE_RANGE;
+  }
+
+  function rangeLabel(range) {
+    const option = RELEASE_RANGE_OPTIONS.find((candidate) => candidate.value === range);
+    return option ? option.label : RELEASE_RANGE_OPTIONS[0].label;
+  }
+
+  function timestampLabel(value) {
+    const timestamp = stringValue(value);
+    if (!timestamp) {
+      return EMPTY_CELL;
+    }
+    const parsed = new Date(timestamp);
+    if (Number.isNaN(parsed.getTime())) {
+      return timestamp;
+    }
+    const iso = parsed.toISOString();
+    return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+  }
+
+  function mainSnapshotLabel(data) {
+    const metadata = benchmarkMetadata(data);
+    const measuredAt = timestampLabel(metadata.main_snapshot_generated_at);
+    const sha = stringValue(metadata.main_snapshot_collector_sha);
+    const shaLabel = sha ? ` · ${sha.slice(0, 12)}` : "";
+    return measuredAt === EMPTY_CELL ? "Main snapshot time unavailable" : `Main measured ${measuredAt}${shaLabel}`;
+  }
+
+  function mainSnapshotStatus(data, hasMainSnapshot, hasMainTiming) {
+    if (!hasMainSnapshot) {
+      return "No main snapshot in this scenario";
+    }
+    const label = mainSnapshotLabel(data);
+    return hasMainTiming ? label : `${label} · no successful timing`;
+  }
+
+  function versionRangeLabel(data, versions) {
+    if (versions.length === 0) {
+      return "No release versions";
+    }
+    const firstVersion = versions[0];
+    const lastVersion = versions[versions.length - 1];
+    const firstDate = releaseDate(data, firstVersion);
+    const lastDate = releaseDate(data, lastVersion);
+    if (firstDate === EMPTY_CELL || lastDate === EMPTY_CELL) {
+      return firstVersion === lastVersion ? firstVersion : `${firstVersion}–${lastVersion}`;
+    }
+    return `${firstVersion} (${firstDate})–${lastVersion} (${lastDate})`;
+  }
+
   function releaseDate(data, version) {
     const releaseDates = benchmarkMetadata(data).release_dates;
     if (!releaseDates || typeof releaseDates !== "object" || Array.isArray(releaseDates)) {
@@ -342,12 +472,7 @@
     if (!uploadedAt) {
       return EMPTY_CELL;
     }
-    const parsed = new Date(uploadedAt);
-    if (Number.isNaN(parsed.getTime())) {
-      return uploadedAt;
-    }
-    const iso = parsed.toISOString();
-    return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+    return timestampLabel(uploadedAt);
   }
 
   function ratioLabel(ratio) {
@@ -450,12 +575,28 @@
   }
 
   function chartElement(inputType, caseName) {
-    const container = createElement("span", "release-benchmark-chart");
+    const container = createElement("div", "release-benchmark-chart");
     container.setAttribute("data-release-benchmark-chart", "");
     container.dataset.inputType = inputType;
     container.dataset.case = caseName;
+    container.dataset.releaseBenchmarkSelectedRange = DEFAULT_RELEASE_RANGE;
     container.setAttribute("aria-label", `${caseName} / ${inputLabel(inputType)} release benchmark trend`);
 
+    const controls = createElement("div", "release-benchmark-chart__controls");
+    controls.setAttribute("role", "group");
+    controls.setAttribute("aria-label", "Release range");
+    appendText(controls, "span", "Show:", "release-benchmark-chart__controls-label");
+    RELEASE_RANGE_OPTIONS.forEach((option) => {
+      const button = createElement("button", "release-benchmark-chart__range-button");
+      button.type = "button";
+      button.dataset.releaseBenchmarkRangeOption = option.value;
+      button.setAttribute("aria-pressed", String(option.value === DEFAULT_RELEASE_RANGE));
+      button.textContent = option.label;
+      controls.append(button);
+    });
+    const rangeInfo = createElement("span", "release-benchmark-chart__range-info");
+    rangeInfo.setAttribute("aria-live", "polite");
+    const mainSnapshot = createElement("span", "release-benchmark-chart__main-snapshot");
     const canvas = document.createElement("canvas");
     canvas.setAttribute("role", "img");
     canvas.setAttribute("aria-label", "Median generation time by release version");
@@ -467,7 +608,7 @@
     const tooltip = createElement("span", "release-benchmark-chart__tooltip");
     tooltip.setAttribute("role", "status");
     tooltip.hidden = true;
-    container.append(canvas, legend, status, tooltip);
+    container.append(controls, rangeInfo, mainSnapshot, canvas, legend, status, tooltip);
     return container;
   }
 
@@ -733,12 +874,68 @@
     status.hidden = message === "";
   }
 
+  function updateChartControls(
+    container,
+    data,
+    range,
+    versions,
+    allReleaseVersions,
+    yMax,
+    hasMainSnapshot,
+    hasMainTiming,
+  ) {
+    const rangeInfo = container.querySelector(".release-benchmark-chart__range-info");
+    if (rangeInfo) {
+      rangeInfo.textContent =
+        `Showing ${rangeLabel(range)} (${versionRangeLabel(data, versions)}) ` +
+        `of ${allReleaseVersions.length} release versions · scale 0–${formatMs(yMax)}`;
+    }
+    const mainSnapshot = container.querySelector(".release-benchmark-chart__main-snapshot");
+    if (mainSnapshot) {
+      mainSnapshot.textContent = mainSnapshotStatus(data, hasMainSnapshot, hasMainTiming);
+    }
+    container.querySelectorAll("[data-release-benchmark-range-option]").forEach((button) => {
+      button.setAttribute("aria-pressed", String(button.dataset.releaseBenchmarkRangeOption === range));
+    });
+  }
+
+  function setChartRange(container, range) {
+    if (!RELEASE_RANGE_OPTIONS.some((option) => option.value === range)) {
+      return;
+    }
+    if (chartRange(container) === range) {
+      return;
+    }
+    container.dataset.releaseBenchmarkSelectedRange = range;
+    hideTooltip(container);
+    if (benchmarkPayload) {
+      drawChart(container, benchmarkPayload.data, benchmarkPayload.notes);
+    }
+  }
+
   function chartSize(canvas) {
     const rect = canvas.getBoundingClientRect();
     const style = getComputedStyle(canvas);
     const width = Math.max(320, Math.floor(rect.width));
     const height = Math.max(260, Number.parseFloat(style.height) || 420);
     return { width, height };
+  }
+
+  function clearCanvas(canvas) {
+    const { width, height } = chartSize(canvas);
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(width * devicePixelRatio);
+    canvas.height = Math.floor(height * devicePixelRatio);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return null;
+    }
+    context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+    context.clearRect(0, 0, width, height);
+    return { context, width, height };
   }
 
   function isVisible(element) {
@@ -758,28 +955,33 @@
     const caseName = container.dataset.case || "";
     const entries = scenarioEntries(data, inputType, caseName);
     const notesByVersion = scenarioNotesByVersion(notes, inputType, caseName);
-    const versions = Array.from(new Set(entries.map((entry) => entry.version))).sort(compareVersions);
-    const okEntries = entries.filter((entry) => entry.status === STATUS_OK && typeof entry.median_ms === "number");
+    const range = chartRange(container);
+    const { allReleaseVersions, versions, visibleEntries, mainEntries, hasMain, timingEntryCount, yMax } =
+      chartSelection(entries, range);
+    const hasMainSnapshot = mainEntries.length > 0;
+    const chart = clearCanvas(canvas);
+    if (!chart) {
+      return;
+    }
+    const { context, width, height } = chart;
 
-    if (versions.length === 0 || okEntries.length === 0) {
+    if (timingEntryCount === 0) {
+      updateChartControls(
+        container,
+        data,
+        range,
+        versions,
+        allReleaseVersions,
+        1,
+        hasMainSnapshot,
+        hasMain,
+      );
       setStatus(container, "No benchmark data is available for this chart.");
+      container.releaseBenchmarkPoints = [];
+      container.releaseBenchmarkNotes = [];
       return;
     }
     setStatus(container, "");
-
-    const { width, height } = chartSize(canvas);
-    const devicePixelRatio = window.devicePixelRatio || 1;
-    canvas.width = Math.floor(width * devicePixelRatio);
-    canvas.height = Math.floor(height * devicePixelRatio);
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-
-    const context = canvas.getContext("2d");
-    if (!context) {
-      return;
-    }
-    context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-    context.clearRect(0, 0, width, height);
 
     const foreground = cssColor(container, "--md-default-fg-color", "#111827");
     const muted = cssColor(container, "--md-default-fg-color--light", "#6b7280");
@@ -787,18 +989,46 @@
     const noteColor = cssColor(container, "--md-accent-fg-color", "#dc2626");
     context.font = "12px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
     const horizontalLabelPadding = Math.ceil(maxVersionLabelWidth(context, versions) / 2) + 8;
+    const mainPanel = mainPanelBounds(width, horizontalLabelPadding, hasMain);
     const plot = {
       left: Math.max(58, horizontalLabelPadding),
       top: 38,
-      right: width - Math.max(18, horizontalLabelPadding),
+      right: mainPanel ? mainPanel.plotRight : width - Math.max(18, horizontalLabelPadding),
       bottom: height - 58,
     };
-    const maxMs = Math.max(...okEntries.map((entry) => entry.median_ms || 0));
-    const yMax = maxMs > 0 ? maxMs * 1.15 : 1;
     const points = [];
+    updateChartControls(
+      container,
+      data,
+      range,
+      versions,
+      allReleaseVersions,
+      yMax,
+      hasMainSnapshot,
+      hasMain,
+    );
 
     context.fillStyle = foreground;
     context.fillText(`${caseName[0].toUpperCase()}${caseName.slice(1)} / ${inputLabel(inputType)}`, plot.left, 20);
+
+    if (mainPanel) {
+      context.save();
+      context.fillStyle = grid;
+      context.globalAlpha = 0.25;
+      context.fillRect(mainPanel.left, plot.top, mainPanel.right - mainPanel.left, plot.bottom - plot.top);
+      context.globalAlpha = 1;
+      context.strokeStyle = muted;
+      context.setLineDash([4, 4]);
+      context.beginPath();
+      context.moveTo(mainPanel.left - 5, plot.top);
+      context.lineTo(mainPanel.left - 5, plot.bottom);
+      context.stroke();
+      context.setLineDash([]);
+      context.fillStyle = muted;
+      context.textAlign = "center";
+      context.fillText("main snapshot", (mainPanel.left + mainPanel.right) / 2, plot.top - 10);
+      context.restore();
+    }
 
     context.strokeStyle = grid;
     context.fillStyle = muted;
@@ -826,6 +1056,10 @@
       context.fillStyle = muted;
       context.fillText(version, x, plot.bottom + 24);
     });
+    if (mainPanel) {
+      context.fillStyle = muted;
+      context.fillText("main", (mainPanel.left + mainPanel.right) / 2, plot.bottom + 24);
+    }
 
     context.strokeStyle = foreground;
     context.beginPath();
@@ -856,38 +1090,51 @@
     context.restore();
 
     FORMATTERS.forEach((formatter) => {
-      const formatterPoints = [];
+      const releasePoints = [];
       versions.forEach((version, index) => {
-        const entry = findEntry(entries, version, formatter.key);
+        const entry = findEntry(visibleEntries, version, formatter.key);
         if (!entry) {
           return;
         }
         const x = scale(index, 0, Math.max(versions.length - 1, 1), plot.left, plot.right);
         const y = scale(entry.median_ms, 0, yMax, plot.bottom, plot.top);
-        formatterPoints.push({ x, y, entry, formatter });
+        releasePoints.push({ x, y, entry, formatter });
         points.push({ x, y, entry, formatter });
       });
-      if (formatterPoints.length === 0) {
+      if (releasePoints.length > 0) {
+        context.strokeStyle = formatter.color;
+        context.lineWidth = 2.4;
+        context.beginPath();
+        releasePoints.forEach((point, index) => {
+          if (index === 0) {
+            context.moveTo(point.x, point.y);
+            return;
+          }
+          context.lineTo(point.x, point.y);
+        });
+        context.stroke();
+
+        context.fillStyle = formatter.color;
+        releasePoints.forEach((point) => {
+          context.beginPath();
+          context.arc(point.x, point.y, 3, 0, Math.PI * 2);
+          context.fill();
+        });
+      }
+      const mainEntry = findEntry(mainEntries, MAIN_VERSION, formatter.key);
+      if (!mainEntry || !mainPanel) {
         return;
       }
-      context.strokeStyle = formatter.color;
-      context.lineWidth = 2.4;
-      context.beginPath();
-      formatterPoints.forEach((point, index) => {
-        if (index === 0) {
-          context.moveTo(point.x, point.y);
-          return;
-        }
-        context.lineTo(point.x, point.y);
-      });
-      context.stroke();
-
+      const x = (mainPanel.left + mainPanel.right) / 2;
+      const y = scale(mainEntry.median_ms, 0, yMax, plot.bottom, plot.top);
+      const point = { x, y, entry: mainEntry, formatter, mainSnapshot: true, snapshotLabel: mainSnapshotLabel(data) };
+      points.push(point);
+      context.save();
       context.fillStyle = formatter.color;
-      formatterPoints.forEach((point) => {
-        context.beginPath();
-        context.arc(point.x, point.y, 3, 0, Math.PI * 2);
-        context.fill();
-      });
+      context.translate(x, y);
+      context.rotate(Math.PI / 4);
+      context.fillRect(-3.5, -3.5, 7, 7);
+      context.restore();
     });
 
     container.releaseBenchmarkPoints = points;
@@ -935,7 +1182,9 @@
       tooltip.hidden = true;
       return;
     }
-    tooltip.textContent = `${nearest.entry.version} · ${nearest.formatter.label}: ${formatMs(nearest.entry.median_ms)}`;
+    const snapshot = nearest.mainSnapshot ? ` · ${nearest.snapshotLabel}` : "";
+    tooltip.textContent =
+      `${nearest.entry.version} · ${nearest.formatter.label}: ` + `${formatMs(nearest.entry.median_ms)}${snapshot}`;
     tooltip.style.left = `${canvas.offsetLeft + nearest.x}px`;
     tooltip.style.top = `${canvas.offsetTop + nearest.y}px`;
     tooltip.hidden = false;
@@ -1040,7 +1289,12 @@
     }
     globalEventsAttached = true;
     window.addEventListener("resize", scheduleInitializedChartsRender);
-    document.addEventListener("click", () => window.setTimeout(scheduleInitializedChartsRender, 50));
+    document.addEventListener("click", (event) => {
+      if (event.target instanceof Element && event.target.closest("[data-release-benchmark-range-option]")) {
+        return;
+      }
+      window.setTimeout(scheduleInitializedChartsRender, 50);
+    });
     document.addEventListener("change", () => window.setTimeout(scheduleInitializedChartsRender, 50));
     document.addEventListener("visibilitychange", scheduleInitializedChartsRender);
   }
@@ -1081,6 +1335,15 @@
     initializedCharts.add(container);
     renderLegend(container);
     setStatus(container, "Loading benchmark chart...");
+    container.addEventListener("click", (event) => {
+      const button = event.target instanceof Element
+        ? event.target.closest("[data-release-benchmark-range-option]")
+        : null;
+      if (!(button instanceof HTMLButtonElement)) {
+        return;
+      }
+      setChartRange(container, button.dataset.releaseBenchmarkRangeOption || "");
+    });
     container.addEventListener("mousemove", (event) => showTooltip(container, event));
     container.addEventListener("mouseleave", () => hideTooltip(container));
     observeChart(container);

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -40223,7 +40223,7 @@ The benchmark data on this page is loaded from `docs/data/release-benchmarks.jso
 - Benchmark results are collected on GitHub Actions CI runners, so median timings can vary slightly with runner load and workflow timing; rerun benchmarks before treating small differences as regressions.
 - The Python version is the workflow input, defaulting to the latest configured CI Python.
 - Release packages are installed from PyPI in isolated virtual environments.
-- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.
+- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces the previous `main` snapshot.
 - Input coverage currently focuses on OpenAPI and JSON Schema.
 - Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.
 

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -39,6 +39,6 @@ The benchmark data on this page is loaded from `docs/data/release-benchmarks.jso
 - Benchmark results are collected on GitHub Actions CI runners, so median timings can vary slightly with runner load and workflow timing; rerun benchmarks before treating small differences as regressions.
 - The Python version is the workflow input, defaulting to the latest configured CI Python.
 - Release packages are installed from PyPI in isolated virtual environments.
-- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.
+- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces the previous `main` snapshot.
 - Input coverage currently focuses on OpenAPI and JSON Schema.
 - Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.

--- a/scripts/build_release_benchmark_docs.py
+++ b/scripts/build_release_benchmark_docs.py
@@ -353,7 +353,10 @@ def render_release_benchmark_markdown(data: BenchmarkData) -> str:
         ),
         "- The Python version is the workflow input, defaulting to the latest configured CI Python.",
         "- Release packages are installed from PyPI in isolated virtual environments.",
-        "- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.",
+        (
+            "- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces "
+            "the previous `main` snapshot."
+        ),
         "- Input coverage currently focuses on OpenAPI and JSON Schema.",
         "- Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.",
         "",

--- a/scripts/collect_release_benchmarks.py
+++ b/scripts/collect_release_benchmarks.py
@@ -354,13 +354,15 @@ def _result_payload(result: BenchmarkResult | dict[str, object]) -> dict[str, ob
 
 
 def _result_version(result: BenchmarkResult | dict[str, object]) -> str:
+    version = ""
     match result:
-        case BenchmarkResult(version=version):
-            return version
+        case BenchmarkResult(version=result_version):
+            version = result_version
         case dict():
-            return str(result.get("version", ""))
+            version = str(result.get("version", ""))
         case _:
-            return ""
+            pass
+    return version
 
 
 def _payload(

--- a/scripts/collect_release_benchmarks.py
+++ b/scripts/collect_release_benchmarks.py
@@ -359,6 +359,8 @@ def _result_version(result: BenchmarkResult | dict[str, object]) -> str:
             return version
         case dict():
             return str(result.get("version", ""))
+        case _:
+            return ""
 
 
 def _payload(

--- a/scripts/collect_release_benchmarks.py
+++ b/scripts/collect_release_benchmarks.py
@@ -29,6 +29,11 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
     from release_benchmark_errors import compact_benchmark_error
 
+try:
+    from scripts.release_benchmark_safety import MAIN_VERSION
+except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    from release_benchmark_safety import MAIN_VERSION
+
 ROOT = Path(__file__).resolve().parents[1]
 GITHUB_PACKAGE_URL = "git+https://github.com/koxudaxi/datamodel-code-generator.git"
 DEFAULT_OUTPUT = ROOT / ".benchmarks" / "release-benchmarks.json"
@@ -42,6 +47,7 @@ TIMEOUT_EXIT_CODE = 124
 STATUS_OK = "ok"
 STATUS_FAILED = "failed"
 STATUS_UNSUPPORTED = "unsupported"
+MAIN_REF_PATTERN = re.compile(rf"^(?:{MAIN_VERSION}|[0-9a-f]{{40}})$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,14 +158,14 @@ def _truncate_error(text: str) -> str:
     return f"{compact[: MAX_ERROR_LENGTH - 3]}..."
 
 
-def _install_spec(version: str) -> str:
-    if (normalized := _normalize_version(version)) == "main":
-        return f"datamodel-code-generator[ruff] @ {GITHUB_PACKAGE_URL}@main"
+def _install_spec(version: str, *, main_ref: str = MAIN_VERSION) -> str:
+    if (normalized := _normalize_version(version)) == MAIN_VERSION:
+        return f"datamodel-code-generator[ruff] @ {GITHUB_PACKAGE_URL}@{main_ref}"
     return f"datamodel-code-generator[ruff]=={normalized}"
 
 
-def _install_command(python_path: Path, version: str) -> list[str]:
-    spec = _install_spec(version)
+def _install_command(python_path: Path, version: str, *, main_ref: str) -> list[str]:
+    spec = _install_spec(version, main_ref=main_ref)
     if uv_path := shutil.which("uv"):
         return [uv_path, "pip", "install", "--python", str(python_path), spec]
     return [str(python_path), "-m", "pip", "install", spec]
@@ -174,8 +180,8 @@ def _create_venv(path: Path) -> Path:
     return _venv_python(path)
 
 
-def _install_release(python_path: Path, version: str, *, timeout: int, retries: int) -> str:
-    command = _install_command(python_path, version)
+def _install_release(python_path: Path, version: str, *, main_ref: str, timeout: int, retries: int) -> str:
+    command = _install_command(python_path, version, main_ref=main_ref)
     last_error = ""
     for attempt in range(retries):
         result = _run_subprocess(command, timeout=timeout)
@@ -321,6 +327,7 @@ def benchmark_version(
     *,
     formatters: tuple[str, ...],
     config: BenchmarkConfig,
+    main_ref: str = MAIN_VERSION,
 ) -> list[BenchmarkResult]:
     """Benchmark one released datamodel-code-generator version."""
     with tempfile.TemporaryDirectory(prefix="datamodel-code-generator-release-bench-") as tmp:
@@ -329,6 +336,7 @@ def benchmark_version(
         if error := _install_release(
             venv_python,
             version,
+            main_ref=main_ref,
             timeout=config.timeout,
             retries=config.install_retries,
         ):
@@ -345,19 +353,41 @@ def _result_payload(result: BenchmarkResult | dict[str, object]) -> dict[str, ob
     return result
 
 
-def _payload(results: list[BenchmarkResult] | list[dict[str, object]], *, runs: int, warmups: int) -> dict[str, object]:
+def _result_version(result: BenchmarkResult | dict[str, object]) -> str:
+    match result:
+        case BenchmarkResult(version=version):
+            return version
+        case dict():
+            return str(result.get("version", ""))
+
+
+def _payload(
+    results: list[BenchmarkResult] | list[dict[str, object]],
+    *,
+    runs: int,
+    warmups: int,
+    main_ref: str = MAIN_VERSION,
+) -> dict[str, object]:
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    metadata = {
+        "generated_at": generated_at,
+        "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
+        "workflow_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "collector_sha": os.environ.get("GITHUB_SHA", ""),
+        "os": _runner_os(),
+        "python_version": platform.python_version(),
+        "runs_per_case": str(runs),
+        "warmups_per_case": str(warmups),
+    }
+    if any(_result_version(result) == MAIN_VERSION for result in results):
+        metadata.update({
+            "main_snapshot_generated_at": generated_at,
+            "main_snapshot_workflow_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+            "main_snapshot_collector_sha": main_ref if re.fullmatch(r"[0-9a-f]{40}", main_ref) else "",
+        })
     return {
         "schema_version": 1,
-        "metadata": {
-            "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
-            "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
-            "workflow_run_id": os.environ.get("GITHUB_RUN_ID", ""),
-            "collector_sha": os.environ.get("GITHUB_SHA", ""),
-            "os": _runner_os(),
-            "python_version": platform.python_version(),
-            "runs_per_case": str(runs),
-            "warmups_per_case": str(warmups),
-        },
+        "metadata": metadata,
         "entries": [_result_payload(result) for result in results],
     }
 
@@ -375,6 +405,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS, help="Warmup runs per case")
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Subprocess timeout in seconds")
     parser.add_argument("--install-retries", type=int, default=DEFAULT_INSTALL_RETRIES, help="PyPI install retry count")
+    parser.add_argument(
+        "--main-ref",
+        default=MAIN_VERSION,
+        help="Exact 40-character commit SHA used when benchmarking main (defaults to the moving main branch)",
+    )
     parser.add_argument(
         "--formatters",
         default=",".join(DEFAULT_FORMATTERS),
@@ -406,6 +441,8 @@ def _validate_args(args: argparse.Namespace) -> str:
         )
         if error
     ]
+    if not MAIN_REF_PATTERN.fullmatch(args.main_ref):
+        errors.append(f"--main-ref must be 'main' or a 40-character lowercase commit SHA, got {args.main_ref!r}")
     if not errors:
         return ""
     return "\n".join(errors)
@@ -438,11 +475,14 @@ def main() -> int:
                 version,
                 formatters=formatters,
                 config=config,
+                main_ref=args.main_ref,
             )
         )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(_payload(results, runs=args.runs, warmups=args.warmups), indent=2) + "\n")
+    args.output.write_text(
+        json.dumps(_payload(results, runs=args.runs, warmups=args.warmups, main_ref=args.main_ref), indent=2) + "\n"
+    )
     print(f"Wrote {args.output}", file=sys.stderr)
     return 0
 

--- a/scripts/merge_release_benchmarks.py
+++ b/scripts/merge_release_benchmarks.py
@@ -20,6 +20,11 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
     from release_benchmark_errors import compact_benchmark_error
 
+try:
+    from scripts.release_benchmark_safety import MAIN_SNAPSHOT_FALLBACK_KEYS, MAIN_SNAPSHOT_METADATA_KEYS, MAIN_VERSION
+except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    from release_benchmark_safety import MAIN_SNAPSHOT_FALLBACK_KEYS, MAIN_SNAPSHOT_METADATA_KEYS, MAIN_VERSION
+
 DEFAULT_OUTPUT = Path(".benchmarks") / "release-benchmarks.json"
 DEFAULT_SELECTION = Path(".benchmarks") / "release-benchmark-selection.json"
 
@@ -39,6 +44,16 @@ def _entries(payload: object, *, path: Path) -> list[dict[str, object]]:
         msg = f"Benchmark fragment {path} must contain an entries list"
         raise TypeError(msg)
     return [_entry_payload(entry) for entry in entries if isinstance(entry, dict)]
+
+
+def _main_snapshot_metadata(entries: list[dict[str, object]], metadata: dict[str, Any]) -> dict[str, object]:
+    if not any(entry.get("version") == MAIN_VERSION for entry in entries):
+        return {}
+    return {
+        key: value
+        for key in MAIN_SNAPSHOT_METADATA_KEYS
+        if (value := metadata.get(key) or metadata.get(MAIN_SNAPSHOT_FALLBACK_KEYS[key]))
+    }
 
 
 def _entry_payload(entry: dict[str, object]) -> dict[str, object]:
@@ -127,10 +142,14 @@ def merge_benchmark_payloads(
     """Merge benchmark result fragments and selection metadata."""
     entries: list[dict[str, object]] = []
     fragment_metadata: list[dict[str, Any]] = []
+    main_snapshot_metadata: dict[str, object] = {}
     for path in fragment_paths:
         payload = _load_json(path)
-        entries.extend(_entries(payload, path=path))
-        fragment_metadata.append(_metadata(payload))
+        fragment_entries = _entries(payload, path=path)
+        metadata = _metadata(payload)
+        entries.extend(fragment_entries)
+        fragment_metadata.append(metadata)
+        main_snapshot_metadata.update(_main_snapshot_metadata(fragment_entries, metadata))
 
     selection = _load_json(selection_path) if selection_path.exists() else {}
     runs = next((metadata.get("runs_per_case") for metadata in fragment_metadata if metadata.get("runs_per_case")), "0")
@@ -142,6 +161,7 @@ def merge_benchmark_payloads(
     payload_metadata = payload["metadata"]
     if isinstance(payload_metadata, dict):
         payload_metadata.update(_selection_metadata(selection))
+        payload_metadata.update(main_snapshot_metadata)
         if generated_at:
             payload_metadata["generated_at"] = generated_at
         payload_metadata["workflow"] = os.environ.get("GITHUB_WORKFLOW", payload_metadata.get("workflow", "local"))

--- a/scripts/merge_release_benchmarks.py
+++ b/scripts/merge_release_benchmarks.py
@@ -52,7 +52,7 @@ def _main_snapshot_metadata(entries: list[dict[str, object]], metadata: dict[str
     return {
         key: value
         for key in MAIN_SNAPSHOT_METADATA_KEYS
-        if (value := metadata.get(key) or metadata.get(MAIN_SNAPSHOT_FALLBACK_KEYS[key]))
+        if (value := metadata.get(key, metadata.get(MAIN_SNAPSHOT_FALLBACK_KEYS[key])))
     }
 
 

--- a/scripts/release_benchmark_safety.py
+++ b/scripts/release_benchmark_safety.py
@@ -11,6 +11,17 @@ if TYPE_CHECKING:
 
 EntryField = tuple[str, re.Pattern[str]]
 
+MAIN_VERSION = "main"
+MAIN_SNAPSHOT_METADATA_KEYS = (
+    "main_snapshot_generated_at",
+    "main_snapshot_workflow_run_id",
+    "main_snapshot_collector_sha",
+)
+MAIN_SNAPSHOT_FALLBACK_KEYS = {
+    "main_snapshot_generated_at": "generated_at",
+    "main_snapshot_workflow_run_id": "workflow_run_id",
+    "main_snapshot_collector_sha": "collector_sha",
+}
 SAFE_LABEL_PATTERN = re.compile(r"^(?:main|[A-Za-z0-9][A-Za-z0-9._+-]*)$")
 SAFE_FIELD_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SAFE_METADATA_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._:/+-]*$")
@@ -49,6 +60,7 @@ INCOMING_METADATA_KEYS = (
     "pypistats_last_month",
     "pypistats_timeseries_days",
     "pypistats_timeseries_downloads",
+    *MAIN_SNAPSHOT_METADATA_KEYS,
 )
 
 
@@ -163,12 +175,13 @@ def safe_metadata_value(metadata: Mapping[str, object], key: str, *, path: Path)
             if (version := safe_release_version(raw_version, path=path, field=key))
         ]
         return ",".join(versions)
-    if isinstance(value, (int, float)):
-        text = str(value)
-    elif isinstance(value, str):
-        text = value.strip()
-    else:
-        return ""
+    match value:
+        case int() | float():
+            text = str(value)
+        case str():
+            text = value.strip()
+        case _:
+            return ""
     if not text:
         return ""
     if SAFE_METADATA_PATTERN.fullmatch(text):

--- a/scripts/select_release_benchmark_versions.py
+++ b/scripts/select_release_benchmark_versions.py
@@ -20,9 +20,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 try:
-    from scripts.release_benchmark_safety import safe_release_version
+    from scripts.release_benchmark_safety import MAIN_VERSION, safe_release_version
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
-    from release_benchmark_safety import safe_release_version
+    from release_benchmark_safety import MAIN_VERSION, safe_release_version
 
 if importlib.util.find_spec("certifi"):
     import certifi
@@ -110,6 +110,7 @@ class SelectionConfig:
     history_days: int
     limit: int
     now: datetime
+    include_main: bool = False
 
 
 def _utc_now() -> datetime:
@@ -274,8 +275,34 @@ def _selected_explicit_releases(
             usage_by_version.get(version),
         )
         for raw_version in _split_csv_words(explicit_versions)
-        if (version := _safe_normalize_version(raw_version))
+        if (version := _safe_normalize_version(raw_version)) and version != MAIN_VERSION
     ][:limit]
+
+
+def _explicit_requests_main(explicit_versions: str) -> bool:
+    return any(_safe_normalize_version(version) == MAIN_VERSION for version in _split_csv_words(explicit_versions))
+
+
+def _is_main_only_request(explicit_versions: str) -> bool:
+    """Return whether explicit input contains only the synthetic main version."""
+    if not (versions := _split_csv_words(explicit_versions)):
+        return False
+    return all(_safe_normalize_version(version) == MAIN_VERSION for version in versions)
+
+
+def _main_only_selection(config: SelectionConfig) -> VersionSelection:
+    """Build selection metadata without reading external release or download sources."""
+    return VersionSelection(
+        schema_version=1,
+        generated_at=_timestamp(config.now),
+        package=PACKAGE_NAME,
+        strategy="explicit",
+        history_days=config.history_days,
+        limit=config.limit,
+        selected_versions=[MAIN_VERSION],
+        releases=[],
+        download_stats={},
+    )
 
 
 def _selected_usage_releases(
@@ -373,6 +400,9 @@ def _load_clickpy_usage(
 
 def select_versions(config: SelectionConfig) -> VersionSelection:
     """Resolve benchmark release versions and package download metadata."""
+    if _is_main_only_request(config.explicit_versions):
+        return _main_only_selection(config)
+
     releases = _release_versions(_read_json(config.pypi_source))
     usage, clickpy_stats = _load_clickpy_usage(
         config.clickpy_source,
@@ -404,6 +434,9 @@ def select_versions(config: SelectionConfig) -> VersionSelection:
         **clickpy_stats,
         "pypistats": _load_pypistats(config.recent_source, config.overall_source),
     }
+    selected_versions = [release.version for release in selected]
+    if config.include_main or _explicit_requests_main(config.explicit_versions):
+        selected_versions.append(MAIN_VERSION)
     return VersionSelection(
         schema_version=1,
         generated_at=_timestamp(config.now),
@@ -411,7 +444,7 @@ def select_versions(config: SelectionConfig) -> VersionSelection:
         strategy=strategy,
         history_days=config.history_days,
         limit=config.limit,
-        selected_versions=[release.version for release in selected],
+        selected_versions=selected_versions,
         releases=selected,
         download_stats=download_stats,
     )
@@ -452,6 +485,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--versions", default="", help="Comma, whitespace, or newline separated release versions/tags")
     parser.add_argument("--history-days", type=int, default=DEFAULT_HISTORY_DAYS, help="Release upload lookback window")
     parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Maximum selected release versions")
+    parser.add_argument(
+        "--include-main",
+        action="store_true",
+        help="Append the current main branch snapshot without counting it against the release limit",
+    )
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Selection JSON output path")
     parser.add_argument("--pypi-json", default=PYPI_JSON_URL, help="PyPI project JSON URL or fixture path")
     parser.add_argument("--clickpy-json", default=None, help="ClickPy version-download JSON fixture path")
@@ -479,6 +517,7 @@ def main() -> int:
             history_days=args.history_days,
             limit=args.limit,
             now=now,
+            include_main=args.include_main,
         )
     )
     if not selection.selected_versions:

--- a/scripts/update_release_benchmark_history.py
+++ b/scripts/update_release_benchmark_history.py
@@ -11,12 +11,17 @@ import argparse
 import json
 import os
 import platform
+import re
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 try:
     from scripts.release_benchmark_safety import (
+        MAIN_SNAPSHOT_FALLBACK_KEYS,
+        MAIN_SNAPSHOT_METADATA_KEYS,
+        MAIN_VERSION,
         safe_incoming_metadata,
         safe_release_dates,
         safe_release_version,
@@ -27,6 +32,9 @@ try:
     )
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
     from release_benchmark_safety import (
+        MAIN_SNAPSHOT_FALLBACK_KEYS,
+        MAIN_SNAPSHOT_METADATA_KEYS,
+        MAIN_VERSION,
         safe_incoming_metadata,
         safe_release_dates,
         safe_release_version,
@@ -42,6 +50,19 @@ DEFAULT_INCOMING_DATA = ROOT / ".benchmarks" / "release-benchmarks.json"
 DEFAULT_OUTPUT = DEFAULT_BASE_DATA
 
 EntryKey = tuple[str, str, str, str]
+MAIN_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryMergeOptions:
+    """Optional controls for one history merge."""
+
+    selection_path: Path | None = None
+    generated_at: str = ""
+    current_main_sha: str = ""
+
+
+DEFAULT_HISTORY_MERGE_OPTIONS = HistoryMergeOptions()
 
 
 def _timestamp() -> str:
@@ -100,11 +121,34 @@ def _entry_sort_key(entry: dict[str, object]) -> tuple[tuple[int, int, int, int,
     return version_sort_key(version), input_type, case, formatter
 
 
+def _contains_main_snapshot(entries: list[dict[str, object]]) -> bool:
+    """Return whether a benchmark payload includes the synthetic main snapshot."""
+    return any(_entry_key(entry)[0] == MAIN_VERSION for entry in entries)
+
+
+def _current_main_entries(
+    entries: list[dict[str, object]], incoming_metadata: dict[str, object], current_main_sha: str
+) -> list[dict[str, object]]:
+    """Exclude a main snapshot when it no longer matches the repository's main SHA."""
+    if not current_main_sha or not _contains_main_snapshot(entries):
+        return entries
+    if _string(incoming_metadata.get("main_snapshot_collector_sha")) == current_main_sha:
+        return entries
+    return [entry for entry in entries if _entry_key(entry)[0] != MAIN_VERSION]
+
+
 def _merged_entries(
     base_entries: list[dict[str, object]], incoming_entries: list[dict[str, object]]
 ) -> list[dict[str, object]]:
     incoming_by_key = {_entry_key(entry): entry for entry in incoming_entries}
-    merged_by_key = {_entry_key(entry): entry for entry in base_entries if _entry_key(entry) not in incoming_by_key}
+    replaces_main = _contains_main_snapshot(incoming_entries)
+    merged_by_key: dict[EntryKey, dict[str, object]] = {}
+    for entry in base_entries:
+        if (entry_key := _entry_key(entry)) in incoming_by_key:
+            continue
+        if replaces_main and entry_key[0] == MAIN_VERSION:
+            continue
+        merged_by_key[entry_key] = entry
     merged_by_key.update(incoming_by_key)
     return sorted(merged_by_key.values(), key=_entry_sort_key)
 
@@ -203,7 +247,7 @@ def _merged_metadata(
     safe_incoming = safe_incoming_metadata(incoming_metadata, path=DEFAULT_INCOMING_DATA)
     metadata: dict[str, object] = {
         **base_metadata,
-        **safe_incoming,
+        **{key: value for key, value in safe_incoming.items() if key not in MAIN_SNAPSHOT_METADATA_KEYS},
     }
     versions = _unique_versions(entries)
     fallback_runs = _string(safe_incoming.get("runs_per_case")) or _string(base_metadata.get("runs_per_case"))
@@ -221,7 +265,20 @@ def _merged_metadata(
     })
     if last_month := _int_string(safe_incoming.get("pypistats_last_month")):
         metadata["pypistats_last_month"] = last_month
+    if not _contains_main_snapshot(entries):
+        for key in MAIN_SNAPSHOT_METADATA_KEYS:
+            metadata.pop(key, None)
     return metadata
+
+
+def _update_main_snapshot_metadata(metadata: dict[str, object], incoming_metadata: dict[str, object]) -> None:
+    """Replace metadata describing the main snapshot in place."""
+    safe_incoming = safe_incoming_metadata(incoming_metadata, path=DEFAULT_INCOMING_DATA)
+    for key in MAIN_SNAPSHOT_METADATA_KEYS:
+        if value := _string(safe_incoming.get(key)) or _string(safe_incoming.get(MAIN_SNAPSHOT_FALLBACK_KEYS[key])):
+            metadata[key] = value
+        else:
+            metadata.pop(key, None)
 
 
 def merge_release_benchmark_history(
@@ -229,8 +286,7 @@ def merge_release_benchmark_history(
     base_data_path: Path,
     incoming_data_path: Path,
     output_path: Path,
-    selection_path: Path | None = None,
-    generated_at: str = "",
+    options: HistoryMergeOptions = DEFAULT_HISTORY_MERGE_OPTIONS,
 ) -> dict[str, object]:
     """Merge incoming release benchmark data into committed historical data."""
     base_payload = _payload(base_data_path)
@@ -238,19 +294,26 @@ def merge_release_benchmark_history(
         msg = f"Incoming benchmark data not found: {incoming_data_path}"
         raise FileNotFoundError(msg)
     incoming_payload = _payload(incoming_data_path)
-    entries = _merged_entries(
-        _entries(base_payload, path=base_data_path),
-        _entries(incoming_payload, path=incoming_data_path),
+    base_entries = _entries(base_payload, path=base_data_path)
+    incoming_entries = _entries(incoming_payload, path=incoming_data_path)
+    if options.current_main_sha and not MAIN_SHA_PATTERN.fullmatch(options.current_main_sha):
+        msg = f"--current-main-sha must be a 40-character lowercase commit SHA, got {options.current_main_sha!r}"
+        raise ValueError(msg)
+    base_entries = _current_main_entries(base_entries, _metadata(base_payload), options.current_main_sha)
+    incoming_entries = _current_main_entries(incoming_entries, _metadata(incoming_payload), options.current_main_sha)
+    entries = _merged_entries(base_entries, incoming_entries)
+    metadata = _merged_metadata(
+        _metadata(base_payload),
+        _metadata(incoming_payload),
+        entries,
+        selection_path=options.selection_path,
+        generated_at=options.generated_at,
     )
+    if _contains_main_snapshot(incoming_entries):
+        _update_main_snapshot_metadata(metadata, _metadata(incoming_payload))
     payload = {
         "schema_version": incoming_payload.get("schema_version") or base_payload.get("schema_version") or 1,
-        "metadata": _merged_metadata(
-            _metadata(base_payload),
-            _metadata(incoming_payload),
-            entries,
-            selection_path=selection_path,
-            generated_at=generated_at,
-        ),
+        "metadata": metadata,
         "entries": entries,
     }
     _write_json(output_path, payload)
@@ -264,6 +327,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--incoming-data", type=Path, default=DEFAULT_INCOMING_DATA, help="New benchmark JSON artifact")
     parser.add_argument("--selection", type=Path, default=None, help="Optional refreshed release selection JSON")
     parser.add_argument("--generated-at", default="", help="UTC generated_at override for deterministic tests")
+    parser.add_argument(
+        "--current-main-sha",
+        default="",
+        help="Discard an incoming main snapshot unless it matches this 40-character commit SHA",
+    )
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Merged benchmark history JSON output")
     return parser.parse_args(argv)
 
@@ -275,8 +343,11 @@ def main(argv: list[str] | None = None) -> int:
         base_data_path=args.base_data,
         incoming_data_path=args.incoming_data,
         output_path=args.output,
-        selection_path=args.selection,
-        generated_at=args.generated_at,
+        options=HistoryMergeOptions(
+            selection_path=args.selection,
+            generated_at=args.generated_at,
+            current_main_sha=args.current_main_sha,
+        ),
     )
     print(f"Wrote {args.output}", file=sys.stderr)
     return 0

--- a/tests/data/expected/release_benchmark_docs/collect_release_benchmark_install_specs.txt
+++ b/tests/data/expected/release_benchmark_docs/collect_release_benchmark_install_specs.txt
@@ -1,2 +1,3 @@
 release: datamodel-code-generator[ruff]==0.65.0
 main: datamodel-code-generator[ruff] @ git+https://github.com/koxudaxi/datamodel-code-generator.git@main
+pinned-main: datamodel-code-generator[ruff] @ git+https://github.com/koxudaxi/datamodel-code-generator.git@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/data/expected/release_benchmark_docs/collect_release_benchmark_main_snapshot_metadata.txt
+++ b/tests/data/expected/release_benchmark_docs/collect_release_benchmark_main_snapshot_metadata.txt
@@ -1,0 +1,4 @@
+entries: 2
+main snapshot sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+main snapshot timestamp: True
+main snapshot run id matches collector: True

--- a/tests/data/expected/release_benchmark_docs/merge_release_benchmarks_main_snapshot_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/merge_release_benchmarks_main_snapshot_cli_outputs.txt
@@ -1,0 +1,43 @@
+returncode: 0
+stdout:
+stderr:
+Wrote <tmp>/release-benchmarks.json
+merged:
+{
+  "schema_version": 1,
+  "metadata": {
+    "generated_at": "2026-06-23T00:01:00Z",
+    "workflow": "Release Benchmarks",
+    "workflow_run_id": "merge-run",
+    "collector_sha": "merge-job-sha",
+    "os": "ubuntu-24.04",
+    "python_version": "3.14.2",
+    "runs_per_case": "3",
+    "warmups_per_case": "1",
+    "selection_strategy": "",
+    "selection_window_days": "",
+    "selected_versions": "main",
+    "download_source": "",
+    "download_window_days": "",
+    "download_versions": "",
+    "download_window_total": "",
+    "pypistats_source": "",
+    "pypistats_last_day": "",
+    "pypistats_last_week": "",
+    "pypistats_last_month": "",
+    "pypistats_timeseries_days": "",
+    "pypistats_timeseries_downloads": "",
+    "release_dates": {},
+    "main_snapshot_generated_at": "2026-06-23T00:00:00Z",
+    "main_snapshot_workflow_run_id": "main-run",
+    "main_snapshot_collector_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "entries": [
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/expected/release_benchmark_docs/merge_release_benchmarks_unpinned_main_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/merge_release_benchmarks_unpinned_main_cli_outputs.txt
@@ -1,0 +1,6 @@
+returncode: 0
+stdout:
+stderr:
+Wrote <tmp>/release-benchmarks.json
+main snapshot sha present: False
+merged collector sha: merge-job-sha

--- a/tests/data/expected/release_benchmark_docs/release_benchmark_chart_range_contract.txt
+++ b/tests/data/expected/release_benchmark_docs/release_benchmark_chart_range_contract.txt
@@ -1,0 +1,76 @@
+main snapshot input: 2026-09-04T12:00:00Z
+generated chart host: True
+node chart model:
+{
+  "defaultRange": "10",
+  "rangeOptions": [
+    "10",
+    "25",
+    "all"
+  ],
+  "latest10": {
+    "firstRelease": "0.66.0",
+    "lastRelease": "0.75.0",
+    "timingEntries": 11,
+    "detachedMainEntries": 1,
+    "hasMainTiming": true,
+    "yMax": 144.9
+  },
+  "latest25": {
+    "firstRelease": "0.51.0",
+    "lastRelease": "0.75.0",
+    "timingEntries": 26,
+    "detachedMainEntries": 1,
+    "hasMainTiming": true,
+    "yMax": 144.9
+  },
+  "all": {
+    "firstRelease": "0.50.0",
+    "lastRelease": "0.75.0",
+    "timingEntries": 27,
+    "detachedMainEntries": 1,
+    "hasMainTiming": true,
+    "yMax": 11500
+  },
+  "smallWidth": {
+    "left": 247,
+    "right": 312,
+    "plotRight": 187
+  },
+  "noMainPanel": null,
+  "failedMain": {
+    "cappedRange": {
+      "firstRelease": "0.1.0",
+      "lastRelease": "0.2.0",
+      "timingEntries": 2,
+      "detachedMainEntries": 1,
+      "hasMainTiming": false,
+      "yMax": 46
+    },
+    "invalidRange": {
+      "firstRelease": "0.1.0",
+      "lastRelease": "0.2.0",
+      "timingEntries": 2,
+      "detachedMainEntries": 1,
+      "hasMainTiming": false,
+      "yMax": 46
+    },
+    "status": "Main measured 2026-09-05 01:02 UTC · abcdef012345 · no successful timing"
+  },
+  "emptyTimings": {
+    "selection": {
+      "firstRelease": "0.3.0",
+      "lastRelease": "0.3.0",
+      "timingEntries": 0,
+      "detachedMainEntries": 1,
+      "hasMainTiming": false,
+      "yMax": 1
+    },
+    "noSnapshotStatus": "No main snapshot in this scenario"
+  }
+}
+main timestamp: True
+canvas clears before empty status: True
+main split: True
+range fast path: True
+range controls style: True

--- a/tests/data/expected/release_benchmark_docs/release_benchmark_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/release_benchmark_cli_outputs.txt
@@ -42,6 +42,6 @@ The benchmark data on this page is loaded from `docs/data/release-benchmarks.jso
 - Benchmark results are collected on GitHub Actions CI runners, so median timings can vary slightly with runner load and workflow timing; rerun benchmarks before treating small differences as regressions.
 - The Python version is the workflow input, defaulting to the latest configured CI Python.
 - Release packages are installed from PyPI in isolated virtual environments.
-- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.
+- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces the previous `main` snapshot.
 - Input coverage currently focuses on OpenAPI and JSON Schema.
 - Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.

--- a/tests/data/expected/release_benchmark_docs/release_benchmark_escaped_hostile_text.txt
+++ b/tests/data/expected/release_benchmark_docs/release_benchmark_escaped_hostile_text.txt
@@ -36,6 +36,6 @@ The benchmark data on this page is loaded from `docs/data/release-benchmarks.jso
 - Benchmark results are collected on GitHub Actions CI runners, so median timings can vary slightly with runner load and workflow timing; rerun benchmarks before treating small differences as regressions.
 - The Python version is the workflow input, defaulting to the latest configured CI Python.
 - Release packages are installed from PyPI in isolated virtual environments.
-- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.
+- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces the previous `main` snapshot.
 - Input coverage currently focuses on OpenAPI and JSON Schema.
 - Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.

--- a/tests/data/expected/release_benchmark_docs/release_benchmark_rendered.txt
+++ b/tests/data/expected/release_benchmark_docs/release_benchmark_rendered.txt
@@ -40,6 +40,6 @@ The benchmark data on this page is loaded from `docs/data/release-benchmarks.jso
 - Benchmark results are collected on GitHub Actions CI runners, so median timings can vary slightly with runner load and workflow timing; rerun benchmarks before treating small differences as regressions.
 - The Python version is the workflow input, defaulting to the latest configured CI Python.
 - Release packages are installed from PyPI in isolated virtual environments.
-- The `main` snapshot is installed from the GitHub repository when it is explicitly selected.
+- Every benchmark update measures `main` from an exact commit resolved at workflow start and replaces the previous `main` snapshot.
 - Input coverage currently focuses on OpenAPI and JSON Schema.
 - Historical updates commit `docs/data/release-benchmarks.json`; the page renders that JSON client-side.

--- a/tests/data/expected/release_benchmark_docs/release_benchmark_workflow_sync_contract.txt
+++ b/tests/data/expected/release_benchmark_docs/release_benchmark_workflow_sync_contract.txt
@@ -1,0 +1,11 @@
+queue max: True
+push coalescing: True
+independent non-push runs: True
+serialized data writer: True
+fixed sync branch: True
+trusted checkout: True
+pending diff guard: True
+pending data extraction: True
+current sha guard: True
+existing PR body preserved: True
+new PR body empty: True

--- a/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_invalid_external.txt
+++ b/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_invalid_external.txt
@@ -1,3 +1,3 @@
 releases: 0.64.1
 usage: 0.64.1
-selected: 0.64.1,main
+selected: 0.64.1

--- a/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_main_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_main_cli_outputs.txt
@@ -1,0 +1,40 @@
+returncode: 0
+stdout:
+0.64.1,main
+stderr:
+selection:
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-22T00:00:00Z",
+  "package": "datamodel-code-generator",
+  "strategy": "explicit",
+  "history_days": 365,
+  "limit": 1,
+  "selected_versions": [
+    "0.64.1",
+    "main"
+  ],
+  "releases": [
+    {
+      "version": "0.64.1",
+      "uploaded_at": "2026-06-19T00:00:00Z",
+      "downloads": 25,
+      "first_seen": "2026-06-19",
+      "last_seen": "2026-06-20"
+    }
+  ],
+  "download_stats": {
+    "source": "clickpy",
+    "window_days": "365",
+    "versions_with_downloads": "4",
+    "window_downloads": "1975",
+    "pypistats": {
+      "source": "pypistats.org",
+      "last_day": 12,
+      "last_week": 789,
+      "last_month": 3456,
+      "timeseries_days": 2,
+      "timeseries_downloads": 300
+    }
+  }
+}

--- a/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_main_fast_path_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/select_release_benchmark_versions_main_fast_path_cli_outputs.txt
@@ -1,0 +1,18 @@
+returncode: 0
+stdout:
+main
+stderr:
+selection:
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-22T00:00:00Z",
+  "package": "datamodel-code-generator",
+  "strategy": "explicit",
+  "history_days": 365,
+  "limit": 40,
+  "selected_versions": [
+    "main"
+  ],
+  "releases": [],
+  "download_stats": {}
+}

--- a/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_current_main_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_current_main_cli_outputs.txt
@@ -1,0 +1,43 @@
+returncode: 0
+stdout:
+stderr:
+Wrote <tmp>/release-benchmarks.json
+merged:
+{
+  "schema_version": 1,
+  "metadata": {
+    "main_snapshot_generated_at": "2026-06-24T00:00:00Z",
+    "main_snapshot_workflow_run_id": "current-run",
+    "main_snapshot_collector_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "generated_at": "2026-06-23T00:01:00Z",
+    "workflow_run_id": "new-run",
+    "collector_sha": "collector-sha",
+    "workflow": "",
+    "os": "ubuntu-24.04",
+    "python_version": "",
+    "runs_per_case": "",
+    "selection_strategy": "",
+    "selected_versions": "0.64.1,main",
+    "release_dates": {}
+  },
+  "entries": [
+    {
+      "version": "0.64.1",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "builtin"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_edges.txt
+++ b/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_edges.txt
@@ -20,6 +20,7 @@ missing-selection: {}
 unsafe-metadata: unsafe-metadata.json: ValueError: Benchmark metadata in <tmp>/unsafe-metadata.json has unsafe workflow: '<script>'
 safe-metadata: unsafe-metadata.json: {'workflow': 'Release Benchmarks', 'selected_versions': '0.64.1,main'}
 missing-incoming: sample.json: FileNotFoundError: Incoming benchmark data not found: <tmp>/missing-incoming.json
+invalid-current-main-sha: sample.json: ValueError: --current-main-sha must be a 40-character lowercase commit SHA, got 'not-a-sha'
 blank-metadata: {}
 empty-release-date-version: {}
 merged-release-dates-preserve: {'0.64.1': '2026-06-19T00:00:00Z'}

--- a/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_main_snapshot_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_main_snapshot_cli_outputs.txt
@@ -1,0 +1,37 @@
+returncode: 0
+stdout:
+stderr:
+Wrote <tmp>/release-benchmarks.json
+merged:
+{
+  "schema_version": 1,
+  "metadata": {
+    "main_snapshot_generated_at": "2026-06-23T00:00:00Z",
+    "main_snapshot_workflow_run_id": "new-run",
+    "main_snapshot_collector_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "generated_at": "2026-06-23T00:01:00Z",
+    "workflow_run_id": "new-run",
+    "collector_sha": "collector-sha",
+    "workflow": "",
+    "os": "ubuntu-24.04",
+    "python_version": "",
+    "runs_per_case": "",
+    "selection_strategy": "",
+    "selected_versions": "0.64.1,main",
+    "release_dates": {}
+  },
+  "entries": [
+    {
+      "version": "0.64.1",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_stale_main_cli_outputs.txt
+++ b/tests/data/expected/release_benchmark_docs/update_release_benchmark_history_stale_main_cli_outputs.txt
@@ -1,0 +1,28 @@
+returncode: 0
+stdout:
+stderr:
+Wrote <tmp>/release-benchmarks.json
+merged:
+{
+  "schema_version": 1,
+  "metadata": {
+    "generated_at": "2026-06-23T00:01:00Z",
+    "workflow_run_id": "new-run",
+    "collector_sha": "collector-sha",
+    "workflow": "",
+    "os": "ubuntu-24.04",
+    "python_version": "",
+    "runs_per_case": "",
+    "selection_strategy": "",
+    "selected_versions": "0.64.1",
+    "release_dates": {}
+  },
+  "entries": [
+    {
+      "version": "0.64.1",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/chart_range_edge_cases.json
+++ b/tests/data/release_benchmarks/chart_range_edge_cases.json
@@ -1,0 +1,55 @@
+{
+  "failed_main": {
+    "metadata": {
+      "main_snapshot_generated_at": "2026-09-05T01:02:03Z",
+      "main_snapshot_collector_sha": "abcdef0123456789abcdef0123456789abcdef01"
+    },
+    "entries": [
+      {
+        "version": "0.1.0",
+        "input_type": "jsonschema",
+        "case": "small",
+        "formatter": "default",
+        "status": "ok",
+        "median_ms": 20
+      },
+      {
+        "version": "0.2.0",
+        "input_type": "jsonschema",
+        "case": "small",
+        "formatter": "default",
+        "status": "ok",
+        "median_ms": 40
+      },
+      {
+        "version": "main",
+        "input_type": "jsonschema",
+        "case": "small",
+        "formatter": "default",
+        "status": "failed",
+        "median_ms": null
+      }
+    ]
+  },
+  "empty_timings": {
+    "metadata": {},
+    "entries": [
+      {
+        "version": "0.3.0",
+        "input_type": "jsonschema",
+        "case": "small",
+        "formatter": "default",
+        "status": "failed",
+        "median_ms": null
+      },
+      {
+        "version": "main",
+        "input_type": "jsonschema",
+        "case": "small",
+        "formatter": "default",
+        "status": "failed",
+        "median_ms": null
+      }
+    ]
+  }
+}

--- a/tests/data/release_benchmarks/chart_ranges.json
+++ b/tests/data/release_benchmarks/chart_ranges.json
@@ -1,0 +1,254 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "generated_at": "2026-09-04T12:34:56Z",
+    "main_snapshot_generated_at": "2026-09-04T12:00:00Z",
+    "main_snapshot_collector_sha": "0123456789abcdef0123456789abcdef01234567",
+    "release_dates": {
+      "0.50.0": "2026-08-01T12:00:00Z",
+      "0.51.0": "2026-08-02T12:00:00Z",
+      "0.52.0": "2026-08-03T12:00:00Z",
+      "0.53.0": "2026-08-04T12:00:00Z",
+      "0.54.0": "2026-08-05T12:00:00Z",
+      "0.55.0": "2026-08-06T12:00:00Z",
+      "0.56.0": "2026-08-07T12:00:00Z",
+      "0.57.0": "2026-08-08T12:00:00Z",
+      "0.58.0": "2026-08-09T12:00:00Z",
+      "0.59.0": "2026-08-10T12:00:00Z",
+      "0.60.0": "2026-08-11T12:00:00Z",
+      "0.61.0": "2026-08-12T12:00:00Z",
+      "0.62.0": "2026-08-13T12:00:00Z",
+      "0.63.0": "2026-08-14T12:00:00Z",
+      "0.64.0": "2026-08-15T12:00:00Z",
+      "0.65.0": "2026-08-16T12:00:00Z",
+      "0.66.0": "2026-08-17T12:00:00Z",
+      "0.67.0": "2026-08-18T12:00:00Z",
+      "0.68.0": "2026-08-19T12:00:00Z",
+      "0.69.0": "2026-08-20T12:00:00Z",
+      "0.70.0": "2026-08-21T12:00:00Z",
+      "0.71.0": "2026-08-22T12:00:00Z",
+      "0.72.0": "2026-08-23T12:00:00Z",
+      "0.73.0": "2026-08-24T12:00:00Z",
+      "0.74.0": "2026-08-25T12:00:00Z",
+      "0.75.0": "2026-08-26T12:00:00Z"
+    }
+  },
+  "entries": [
+    {
+      "version": "0.50.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 10000
+    },
+    {
+      "version": "0.51.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 101
+    },
+    {
+      "version": "0.52.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 102
+    },
+    {
+      "version": "0.53.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 103
+    },
+    {
+      "version": "0.54.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 104
+    },
+    {
+      "version": "0.55.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 105
+    },
+    {
+      "version": "0.56.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 106
+    },
+    {
+      "version": "0.57.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 107
+    },
+    {
+      "version": "0.58.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 108
+    },
+    {
+      "version": "0.59.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 109
+    },
+    {
+      "version": "0.60.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 110
+    },
+    {
+      "version": "0.61.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 111
+    },
+    {
+      "version": "0.62.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 112
+    },
+    {
+      "version": "0.63.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 113
+    },
+    {
+      "version": "0.64.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 114
+    },
+    {
+      "version": "0.65.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 115
+    },
+    {
+      "version": "0.66.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 116
+    },
+    {
+      "version": "0.67.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 117
+    },
+    {
+      "version": "0.68.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 118
+    },
+    {
+      "version": "0.69.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 119
+    },
+    {
+      "version": "0.70.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 120
+    },
+    {
+      "version": "0.71.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 121
+    },
+    {
+      "version": "0.72.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 122
+    },
+    {
+      "version": "0.73.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 123
+    },
+    {
+      "version": "0.74.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 124
+    },
+    {
+      "version": "0.75.0",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 125
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default",
+      "status": "ok",
+      "median_ms": 126
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/collector_main_result.json
+++ b/tests/data/release_benchmarks/collector_main_result.json
@@ -1,0 +1,3 @@
+{
+  "version": "main"
+}

--- a/tests/data/release_benchmarks/history_with_current_main_snapshot.json
+++ b/tests/data/release_benchmarks/history_with_current_main_snapshot.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "main_snapshot_generated_at": "2026-06-24T00:00:00Z",
+    "main_snapshot_workflow_run_id": "current-run",
+    "main_snapshot_collector_sha": "cccccccccccccccccccccccccccccccccccccccc"
+  },
+  "entries": [
+    {
+      "version": "0.64.1",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "builtin"
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/history_with_old_main_snapshot.json
+++ b/tests/data/release_benchmarks/history_with_old_main_snapshot.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "main_snapshot_generated_at": "2026-06-01T00:00:00Z",
+    "main_snapshot_workflow_run_id": "old-run",
+    "main_snapshot_collector_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "entries": [
+    {
+      "version": "0.64.1",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    },
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "builtin"
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/incoming_main_snapshot.json
+++ b/tests/data/release_benchmarks/incoming_main_snapshot.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "generated_at": "2026-06-23T00:00:00Z",
+    "workflow_run_id": "new-run",
+    "collector_sha": "collector-sha",
+    "main_snapshot_generated_at": "2026-06-23T00:00:00Z",
+    "main_snapshot_workflow_run_id": "new-run",
+    "main_snapshot_collector_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "entries": [
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/main_only_unavailable_source.json
+++ b/tests/data/release_benchmarks/main_only_unavailable_source.json
@@ -1,0 +1,1 @@
+This fixture is intentionally not JSON. The main-only selection fast path must not read it.

--- a/tests/data/release_benchmarks/main_snapshot_fragment.json
+++ b/tests/data/release_benchmarks/main_snapshot_fragment.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "generated_at": "2026-06-23T00:00:00Z",
+    "workflow_run_id": "main-run",
+    "collector_sha": "collector-sha",
+    "main_snapshot_generated_at": "2026-06-23T00:00:00Z",
+    "main_snapshot_workflow_run_id": "main-run",
+    "main_snapshot_collector_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "runs_per_case": "3",
+    "warmups_per_case": "1"
+  },
+  "entries": [
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/data/release_benchmarks/main_snapshot_selection.json
+++ b/tests/data/release_benchmarks/main_snapshot_selection.json
@@ -1,0 +1,5 @@
+{
+  "selected_versions": [
+    "main"
+  ]
+}

--- a/tests/data/release_benchmarks/main_snapshot_unpinned_fragment.json
+++ b/tests/data/release_benchmarks/main_snapshot_unpinned_fragment.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "generated_at": "2026-06-23T00:00:00Z",
+    "workflow_run_id": "main-run",
+    "collector_sha": "moving-main-collector-sha",
+    "main_snapshot_generated_at": "2026-06-23T00:00:00Z",
+    "main_snapshot_workflow_run_id": "main-run",
+    "main_snapshot_collector_sha": "",
+    "runs_per_case": "3",
+    "warmups_per_case": "1"
+  },
+  "entries": [
+    {
+      "version": "main",
+      "input_type": "jsonschema",
+      "case": "small",
+      "formatter": "default"
+    }
+  ]
+}

--- a/tests/test_build_release_benchmark_docs_script.py
+++ b/tests/test_build_release_benchmark_docs_script.py
@@ -547,6 +547,49 @@ def test_merge_release_benchmarks_carries_main_snapshot_metadata(tmp_path: Path)
     )
 
 
+def test_merge_release_benchmarks_does_not_pin_an_explicitly_unpinned_snapshot(tmp_path: Path) -> None:
+    """An explicit empty snapshot SHA must not fall back to the fragment collector SHA."""
+    output_path = tmp_path / "release-benchmarks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "merge_release_benchmarks.py"),
+            str(FIXTURE_DIR / "main_snapshot_unpinned_fragment.json"),
+            "--selection",
+            str(FIXTURE_DIR / "main_snapshot_selection.json"),
+            "--generated-at",
+            "2026-06-23T00:01:00Z",
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "BENCHMARK_PYTHON_VERSION": "3.14.2",
+            "GITHUB_RUN_ID": "merge-run",
+            "GITHUB_SHA": "merge-job-sha",
+            "GITHUB_WORKFLOW": "Release Benchmarks",
+            "OS": "ubuntu-24.04",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    merged = json.loads(output_path.read_text(encoding="utf-8"))
+    metadata = merged["metadata"]
+    output = _completed_process_output_with_tmp(result, tmp_path) + "\n".join((
+        f"main snapshot sha present: {'main_snapshot_collector_sha' in metadata}",
+        f"merged collector sha: {metadata['collector_sha']}",
+        "",
+    ))
+    assert_output(
+        output,
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "merge_release_benchmarks_unpinned_main_cli_outputs.txt",
+    )
+
+
 def test_merge_release_benchmarks_cli_writes_expected_payload(tmp_path: Path) -> None:
     """The merge CLI combines selection metadata and per-version fragments."""
     selection_path = tmp_path / "release-benchmark-selection.json"

--- a/tests/test_build_release_benchmark_docs_script.py
+++ b/tests/test_build_release_benchmark_docs_script.py
@@ -10,8 +10,18 @@ from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
 
-from scripts import build_release_benchmark_docs, select_release_benchmark_versions, update_release_benchmark_history
-from scripts.collect_release_benchmarks import _failure_status, _install_spec, _run_subprocess
+from scripts import (
+    build_release_benchmark_docs,
+    select_release_benchmark_versions,
+    update_release_benchmark_history,
+)
+from scripts.collect_release_benchmarks import (
+    BenchmarkResult,
+    _failure_status,
+    _install_spec,
+    _payload,
+    _run_subprocess,
+)
 from scripts.release_benchmark_errors import sanitize_benchmark_error, summarize_benchmark_error
 from tests.conftest import assert_output
 
@@ -20,6 +30,8 @@ SCRIPT = ROOT / "scripts" / "build_release_benchmark_docs.py"
 FIXTURE_DATA = ROOT / "tests" / "data" / "release_benchmarks" / "sample.json"
 FIXTURE_DIR = ROOT / "tests" / "data" / "release_benchmarks"
 FIXTURE_NOTES = FIXTURE_DIR / "notes.json"
+CHART_RANGES_FIXTURE = FIXTURE_DIR / "chart_ranges.json"
+CHART_RANGE_EDGE_CASES_FIXTURE = FIXTURE_DIR / "chart_range_edge_cases.json"
 EXPECTED_RELEASE_BENCHMARK_DOCS_PATH = ROOT / "tests" / "data" / "expected" / "release_benchmark_docs"
 
 
@@ -66,6 +78,114 @@ def test_release_benchmark_renderers_use_fixture_data() -> None:
         "\n--- markdown ---\n" + build_release_benchmark_docs.render_release_benchmark_markdown(data),
         EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "release_benchmark_rendered.txt",
     )
+
+
+def test_release_benchmark_chart_range_e2e_uses_fixture_data() -> None:
+    """The chart model executes focused ranges, scaling, and a detached main snapshot."""
+    payload = json.loads(CHART_RANGES_FIXTURE.read_text(encoding="utf-8"))
+    data = build_release_benchmark_docs.load_benchmark_data(CHART_RANGES_FIXTURE, notes_path=None)
+    script_path = ROOT / "docs" / "assets" / "benchmarks" / "release-benchmarks.js"
+    script = script_path.read_text(encoding="utf-8")
+    stylesheet = (ROOT / "docs" / "assets" / "benchmarks" / "release-benchmarks.css").read_text(encoding="utf-8")
+    node_e2e = subprocess.run(
+        [
+            "node",
+            "-e",
+            """
+const chart = require(process.argv[1]);
+const payload = require(process.argv[2]);
+const edgeCases = require(process.argv[3]);
+const summarize = (entries, range) => {
+  const selection = chart.chartSelection(entries, range);
+  return {
+    firstRelease: selection.versions[0],
+    lastRelease: selection.versions.at(-1),
+    timingEntries: selection.timingEntryCount,
+    detachedMainEntries: selection.mainEntries.length,
+    hasMainTiming: selection.hasMain,
+    yMax: Number(selection.yMax.toFixed(1)),
+  };
+};
+console.log(JSON.stringify({
+  defaultRange: chart.DEFAULT_RELEASE_RANGE,
+  rangeOptions: chart.RELEASE_RANGE_OPTIONS.map((option) => option.value),
+  latest10: summarize(payload.entries, '10'),
+  latest25: summarize(payload.entries, '25'),
+  all: summarize(payload.entries, 'all'),
+  smallWidth: chart.mainPanelBounds(320, 60, true),
+  noMainPanel: chart.mainPanelBounds(320, 60, false),
+  failedMain: {
+    cappedRange: summarize(edgeCases.failed_main.entries, '25'),
+    invalidRange: summarize(edgeCases.failed_main.entries, 'invalid'),
+    status: chart.mainSnapshotStatus(edgeCases.failed_main, true, false),
+  },
+  emptyTimings: {
+    selection: summarize(edgeCases.empty_timings.entries, '10'),
+    noSnapshotStatus: chart.mainSnapshotStatus(edgeCases.empty_timings, false, false),
+  },
+}, null, 2));
+""",
+            str(script_path),
+            str(CHART_RANGES_FIXTURE),
+            str(CHART_RANGE_EDGE_CASES_FIXTURE),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(node_e2e)
+    rendered_markdown = build_release_benchmark_docs.render_release_benchmark_markdown(data)
+    clears_before_empty_status = script.index("const chart = clearCanvas(canvas);") < script.index(
+        "if (timingEntryCount === 0)",
+    )
+    range_fast_path = 'event.target.closest("[data-release-benchmark-range-option]")' in script
+    output = "\n".join((
+        f"main snapshot input: {payload['metadata']['main_snapshot_generated_at']}",
+        f"generated chart host: {'data-release-benchmark-app' in rendered_markdown}",
+        "node chart model:",
+        node_e2e.stdout.rstrip(),
+        f"main timestamp: {'main_snapshot_generated_at' in script}",
+        f"canvas clears before empty status: {clears_before_empty_status}",
+        f"main split: {'const mainEntry = findEntry(mainEntries, MAIN_VERSION, formatter.key);' in script}",
+        f"range fast path: {range_fast_path}",
+        f"range controls style: {'release-benchmark-chart__range-button' in stylesheet}",
+        "",
+    ))
+
+    assert_output(output, EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "release_benchmark_chart_range_contract.txt")
+
+
+def test_release_benchmark_workflow_keeps_one_safe_sync_branch() -> None:
+    """The production workflow queues runs and reads pending data without checking out its code."""
+    workflow = (ROOT / ".github" / "workflows" / "release-benchmarks.yaml").read_text(encoding="utf-8")
+    sync_branch = 'sync_branch="docs/release-benchmark-data"'
+    trusted_checkout = 'git checkout -B "$sync_branch" origin/main'
+    pending_diff = 'git diff --name-only "origin/main...refs/remotes/release-benchmark/$sync_branch"'
+    pending_data = 'git show "refs/remotes/release-benchmark/$sync_branch:docs/data/release-benchmarks.json"'
+    current_sha = '--current-main-sha "$current_main_sha"'
+    push_coalescing = "cancel-in-progress: ${{ github.event_name == 'push' }}"
+    independent_runs = "github.run_id"
+    data_writer = "group: release-benchmark-data"
+    new_pr = workflow[workflow.index("gh pr create") :]
+    new_pr_body_empty = '--body ""' in new_pr
+    output = "\n".join((
+        f"queue max: {'queue: max' in workflow}",
+        f"push coalescing: {push_coalescing in workflow}",
+        f"independent non-push runs: {independent_runs in workflow}",
+        f"serialized data writer: {data_writer in workflow}",
+        f"fixed sync branch: {sync_branch in workflow}",
+        f"trusted checkout: {trusted_checkout in workflow}",
+        f"pending diff guard: {pending_diff in workflow}",
+        f"pending data extraction: {pending_data in workflow}",
+        f"current sha guard: {current_sha in workflow}",
+        f"existing PR body preserved: {'gh pr edit' not in workflow}",
+        f"new PR body empty: {new_pr_body_empty}",
+        "",
+    ))
+
+    assert_output(output, EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "release_benchmark_workflow_sync_contract.txt")
 
 
 def test_release_benchmark_docs_cli_writes_expected_outputs(tmp_path: Path) -> None:
@@ -207,14 +327,48 @@ def test_collect_release_benchmark_failure_helpers() -> None:
 
 
 def test_collect_release_benchmark_install_specs() -> None:
-    """Release versions use PyPI pins and main uses the GitHub branch ref."""
+    """Release versions use PyPI pins and main can use an exact GitHub revision."""
     output = "\n".join((
         f"release: {_install_spec('v0.65.0')}",
         f"main: {_install_spec('main')}",
+        f"pinned-main: {_install_spec('main', main_ref='a' * 40)}",
         "",
     ))
 
     assert_output(output, EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "collect_release_benchmark_install_specs.txt")
+
+
+def test_collect_release_benchmark_main_snapshot_metadata_uses_pinned_ref() -> None:
+    """The collector records the resolved main SHA for both result input forms."""
+    fixture_result = json.loads((FIXTURE_DIR / "collector_main_result.json").read_text(encoding="utf-8"))
+    result = BenchmarkResult(
+        version="main",
+        python_version="3.14.2",
+        os="ubuntu-24.04",
+        input_type="jsonschema",
+        case="small",
+        formatter="default",
+        runs=1,
+        median_ms=1.0,
+        min_ms=1.0,
+        max_ms=1.0,
+        stdev_ms=0.0,
+        status="ok",
+        command="python -m datamodel_code_generator",
+        error="",
+    )
+    payload = _payload([result, fixture_result], runs=1, warmups=0, main_ref="a" * 40)
+    metadata = payload["metadata"]
+    snapshot_run_matches_collector = metadata["main_snapshot_workflow_run_id"] == os.environ.get("GITHUB_RUN_ID", "")
+
+    output = "\n".join((
+        f"entries: {len(payload['entries'])}",
+        f"main snapshot sha: {metadata['main_snapshot_collector_sha']}",
+        f"main snapshot timestamp: {bool(metadata['main_snapshot_generated_at'])}",
+        f"main snapshot run id matches collector: {snapshot_run_matches_collector}",
+        "",
+    ))
+    assert_output(output, EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "collect_release_benchmark_main_snapshot_metadata.txt")
 
 
 def test_release_benchmark_error_helpers_redact_public_output() -> None:
@@ -278,6 +432,117 @@ def test_select_release_benchmark_versions_cli_writes_usage_based_selection(tmp_
     assert_output(
         _completed_process_output(result) + "selection:\n" + output_path.read_text(encoding="utf-8"),
         EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "select_release_benchmark_versions_cli_outputs.txt",
+    )
+
+
+def test_select_release_benchmark_versions_can_always_include_main(tmp_path: Path) -> None:
+    """The selector appends main without consuming the release-version limit."""
+    output_path = tmp_path / "release-benchmark-selection.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "select_release_benchmark_versions.py"),
+            "--versions",
+            "0.64.1",
+            "--include-main",
+            "--pypi-json",
+            str(FIXTURE_DIR / "pypi_project.json"),
+            "--clickpy-json",
+            str(FIXTURE_DIR / "clickpy_versions.json"),
+            "--pypistats-recent-json",
+            str(FIXTURE_DIR / "pypistats_recent.json"),
+            "--pypistats-overall-json",
+            str(FIXTURE_DIR / "pypistats_overall.json"),
+            "--limit",
+            "1",
+            "--now",
+            "2026-06-22T00:00:00Z",
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output(result) + "selection:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "select_release_benchmark_versions_main_cli_outputs.txt",
+    )
+
+
+def test_select_release_benchmark_versions_main_only_skips_external_sources(tmp_path: Path) -> None:
+    """The main-only CI path succeeds without reading release or download sources."""
+    output_path = tmp_path / "release-benchmark-selection.json"
+    unavailable_source = FIXTURE_DIR / "main_only_unavailable_source.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "select_release_benchmark_versions.py"),
+            "--versions",
+            "main",
+            "--include-main",
+            "--pypi-json",
+            str(unavailable_source),
+            "--clickpy-json",
+            str(unavailable_source),
+            "--pypistats-recent-json",
+            str(unavailable_source),
+            "--pypistats-overall-json",
+            str(unavailable_source),
+            "--now",
+            "2026-06-22T00:00:00Z",
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output(result) + "selection:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "select_release_benchmark_versions_main_fast_path_cli_outputs.txt",
+    )
+
+
+def test_merge_release_benchmarks_carries_main_snapshot_metadata(tmp_path: Path) -> None:
+    """The merged workflow artifact identifies the exact main commit that was measured."""
+    output_path = tmp_path / "release-benchmarks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "merge_release_benchmarks.py"),
+            str(FIXTURE_DIR / "main_snapshot_fragment.json"),
+            "--selection",
+            str(FIXTURE_DIR / "main_snapshot_selection.json"),
+            "--generated-at",
+            "2026-06-23T00:01:00Z",
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "BENCHMARK_PYTHON_VERSION": "3.14.2",
+            "GITHUB_RUN_ID": "merge-run",
+            "GITHUB_SHA": "merge-job-sha",
+            "GITHUB_WORKFLOW": "Release Benchmarks",
+            "OS": "ubuntu-24.04",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output_with_tmp(result, tmp_path) + "merged:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "merge_release_benchmarks_main_snapshot_cli_outputs.txt",
     )
 
 
@@ -384,8 +649,10 @@ def test_update_release_benchmark_history_empty_base_uses_incoming_metadata(tmp_
         base_data_path=tmp_path / "missing-base.json",
         incoming_data_path=FIXTURE_DIR / "incoming_history_0641.json",
         output_path=output_path,
-        selection_path=FIXTURE_DIR / "pypi_project.json",
-        generated_at="2026-06-23T01:00:00Z",
+        options=update_release_benchmark_history.HistoryMergeOptions(
+            selection_path=FIXTURE_DIR / "pypi_project.json",
+            generated_at="2026-06-23T01:00:00Z",
+        ),
     )
 
     assert_output(
@@ -394,17 +661,115 @@ def test_update_release_benchmark_history_empty_base_uses_incoming_metadata(tmp_
     )
 
 
+def test_update_release_benchmark_history_replaces_the_complete_main_snapshot(tmp_path: Path) -> None:
+    """Fresh main results cannot retain rows or metadata from an older main snapshot."""
+    output_path = tmp_path / "release-benchmarks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "update_release_benchmark_history.py"),
+            "--base-data",
+            str(FIXTURE_DIR / "history_with_old_main_snapshot.json"),
+            "--incoming-data",
+            str(FIXTURE_DIR / "incoming_main_snapshot.json"),
+            "--generated-at",
+            "2026-06-23T00:01:00Z",
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        env={**os.environ, "OS": "ubuntu-24.04"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output_with_tmp(result, tmp_path) + "merged:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "update_release_benchmark_history_main_snapshot_cli_outputs.txt",
+    )
+
+
+def test_update_release_benchmark_history_discards_stale_main_snapshots(tmp_path: Path) -> None:
+    """An out-of-date artifact cannot retain or restore a stale main snapshot."""
+    output_path = tmp_path / "release-benchmarks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "update_release_benchmark_history.py"),
+            "--base-data",
+            str(FIXTURE_DIR / "history_with_old_main_snapshot.json"),
+            "--incoming-data",
+            str(FIXTURE_DIR / "incoming_main_snapshot.json"),
+            "--generated-at",
+            "2026-06-23T00:01:00Z",
+            "--current-main-sha",
+            "c" * 40,
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        env={**os.environ, "OS": "ubuntu-24.04"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output_with_tmp(result, tmp_path) + "merged:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "update_release_benchmark_history_stale_main_cli_outputs.txt",
+    )
+
+
+def test_update_release_benchmark_history_keeps_the_current_main_snapshot(tmp_path: Path) -> None:
+    """A stale artifact cannot replace a base snapshot that matches current main."""
+    output_path = tmp_path / "release-benchmarks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "update_release_benchmark_history.py"),
+            "--base-data",
+            str(FIXTURE_DIR / "history_with_current_main_snapshot.json"),
+            "--incoming-data",
+            str(FIXTURE_DIR / "incoming_main_snapshot.json"),
+            "--generated-at",
+            "2026-06-23T00:01:00Z",
+            "--current-main-sha",
+            "c" * 40,
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        env={**os.environ, "OS": "ubuntu-24.04"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    _raise_for_failed_process(result)
+    assert_output(
+        _completed_process_output_with_tmp(result, tmp_path) + "merged:\n" + output_path.read_text(encoding="utf-8"),
+        EXPECTED_RELEASE_BENCHMARK_DOCS_PATH / "update_release_benchmark_history_current_main_cli_outputs.txt",
+    )
+
+
 def _release_benchmark_history_error(
     path: Path,
     output_path: Path,
     *,
     incoming_data_path: Path = FIXTURE_DIR / "incoming_history_0641.json",
+    options: update_release_benchmark_history.HistoryMergeOptions = (
+        update_release_benchmark_history.DEFAULT_HISTORY_MERGE_OPTIONS
+    ),
 ) -> str:
     try:
         update_release_benchmark_history.merge_release_benchmark_history(
             base_data_path=path,
             incoming_data_path=incoming_data_path,
             output_path=output_path,
+            options=options,
         )
     except (FileNotFoundError, TypeError, ValueError) as exc:
         return f"{path.name}: {type(exc).__name__}: {exc}"
@@ -567,6 +932,12 @@ def test_update_release_benchmark_history_helper_edges(tmp_path: Path) -> None:
             FIXTURE_DATA,
             tmp_path / "unused.json",
             incoming_data_path=tmp_path / "missing-incoming.json",
+        ),
+        "invalid-current-main-sha: "
+        + _release_benchmark_history_error(
+            FIXTURE_DATA,
+            tmp_path / "unused.json",
+            options=update_release_benchmark_history.HistoryMergeOptions(current_main_sha="not-a-sha"),
         ),
         "blank-metadata: "
         + str(update_release_benchmark_history.safe_incoming_metadata({"workflow": "   "}, path=unsafe_metadata)),

--- a/tests/test_build_release_benchmark_docs_script.py
+++ b/tests/test_build_release_benchmark_docs_script.py
@@ -131,6 +131,7 @@ console.log(JSON.stringify({
         ],
         cwd=ROOT,
         capture_output=True,
+        encoding="utf-8",
         text=True,
         check=False,
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release benchmarks now include results for the exact `main` commit used when each run begins.
  - Benchmark records include generation time and workflow details for each `main` snapshot.
  - Benchmark selection supports viewing only the current `main` snapshot or combining it with release versions.
  - Benchmark updates now consolidate pending results before updating published history.

- **Documentation**
  - Updated performance benchmark documentation to explain pinned `main` snapshots and replacement behavior.

- **Bug Fixes**
  - Prevented outdated `main` snapshots and metadata from remaining in benchmark history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->