### PR TITLE
Fix msgspec payload test options

### DIFF
--- a/tests/main/payload_validation/constants.py
+++ b/tests/main/payload_validation/constants.py
@@ -186,6 +186,9 @@ PAYLOAD_BACKEND_EXTRA_ARGS_BY_CASE_ID: dict[str, dict[PayloadBackend, tuple[str,
     "jsonschema/collapse_root_models_property_names_reference.json": dict.fromkeys(
         PayloadBackend, ("--collapse-root-models",)
     ),
+    "jsonschema/msgspec_boolean_enum_literal.json": {
+        PayloadBackend.MSGSPEC: ("--enum-field-as-literal", "all"),
+    },
 }
 ROUND_TRIP_EXCLUDED_CASES: dict[str, str] = {
     "jsonschema/default_factory_nested_model_with_dict.json": (


### PR DESCRIPTION
Fixes: #3859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for payload validation cases involving boolean enum fields represented as literals.
  * Updated test configuration to validate Msgspec generation with literal enum fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->