### PR TITLE
Clarify OpenAPI parameter scopes

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3211,6 +3211,7 @@ Controls which sections of the OpenAPI specification to generate models from.
 | `schemas` | Generate from `#/components/schemas` (default) |
 | `parameters` | Include parameter models for operations selected by `paths` or `webhooks` |
 | `paths` | Generate models from path operation request bodies and responses |
+| `webhooks` | Generate models from webhook operation request bodies and responses |
 
 ### Default behavior (schemas only)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3153,8 +3153,9 @@ readOnly/writeOnly resolution works with local and file reference types:
 | Feature | Generation behavior |
 |---------|---------------------|
 | `components.schemas` | Default model generation scope |
-| `components.parameters` | Generated with `--openapi-scopes parameters` |
+| `components.parameters` | Resolved when referenced by selected operations; no standalone models for unreferenced entries |
 | `paths` operation schemas | Generated with `--openapi-scopes paths` |
+| Operation query parameters | Included with `--openapi-scopes paths parameters`; add `--include-path-parameters` for URL path parameters |
 | `readOnly` / `writeOnly` | Request/response variants with `--read-only-write-only-model-type` |
 | Discriminators and combined schemas | Converted into Python unions and inheritance-aware models where possible |
 | Local and file `$ref` | Resolved before model generation |
@@ -3208,8 +3209,8 @@ Controls which sections of the OpenAPI specification to generate models from.
 | Scope | Description |
 |-------|-------------|
 | `schemas` | Generate from `#/components/schemas` (default) |
-| `parameters` | Generate from `#/components/parameters` |
-| `paths` | Generate from path operation parameters |
+| `parameters` | Include parameter models for operations selected by `paths` or `webhooks` |
+| `paths` | Generate models from path operation request bodies and responses |
 
 ### Default behavior (schemas only)
 
@@ -3219,41 +3220,50 @@ datamodel-codegen --input openapi.yaml --output models.py
 
 Generates models only from `#/components/schemas`.
 
-### Include parameters
+### Include operation schemas
 
 ```bash
 datamodel-codegen --input openapi.yaml --output models.py \
-  --openapi-scopes schemas parameters
+  --openapi-scopes schemas paths
 ```
 
-Also generates models from `#/components/parameters`.
+Also generates models from operation request bodies and responses.
 
-### Include path-level definitions
+### Include operation parameter models
 
 ```bash
 datamodel-codegen --input openapi.yaml --output models.py \
   --openapi-scopes schemas parameters paths
 ```
 
-Generates models from all sources, including inline path operation parameters.
+Also generates a query parameter model for each operation that has query parameters.
+Add `--include-path-parameters` to include URL path parameters in these models.
+Parameters can be declared inline or referenced from `#/components/parameters`.
+Unreferenced entries in `components.parameters` do not generate standalone models,
+and the `parameters` scope alone does not select operations.
 
 ### When to use each scope
 
 | Use Case | Recommended Scopes |
 |----------|-------------------|
 | Basic model generation | `schemas` (default) |
-| Reusable parameter types | `schemas parameters` |
-| Complete API coverage | `schemas parameters paths` |
+| Request and response models | `schemas paths` |
+| Request, response, and query parameter models | `schemas paths parameters` |
 
 ---
 
 ## `--include-path-parameters`
 
-Includes path parameters as fields in generated models.
+Includes path parameters as fields in generated operation parameter models.
+Use this with `--openapi-scopes paths parameters`.
 
 ### OpenAPI Example
 
 ```yaml
+openapi: "3.0.3"
+info:
+  title: Orders API
+  version: "1.0"
 paths:
   /users/{user_id}/orders/{order_id}:
     get:
@@ -3261,42 +3271,41 @@ paths:
       parameters:
         - name: user_id
           in: path
+          required: true
           schema:
             type: string
         - name: order_id
           in: path
+          required: true
           schema:
             type: integer
+      responses:
+        '204':
+          description: No content
 ```
 
 ### Without `--include-path-parameters`
 
-```python
-class GetOrderResponse(BaseModel):
-    # Only response body fields
-    items: list[Item]
-    total: float
-```
+Only query parameters are included in operation parameter models. This example
+has only path parameters, so it does not generate a parameter model without the flag.
 
 ### With `--include-path-parameters`
 
 ```bash
-datamodel-codegen --input openapi.yaml --output models.py --include-path-parameters
+datamodel-codegen --input openapi.yaml --output models.py \
+  --openapi-scopes paths parameters --include-path-parameters --use-operation-id-as-name
 ```
 
 ```python
-class GetOrderResponse(BaseModel):
+class GetOrderParameters(BaseModel):
     user_id: str
     order_id: int
-    items: list[Item]
-    total: float
 ```
 
 ### When to use
 
 - Building request validation models that include URL parameters
-- Creating unified request/response types for API clients
-- Generating models for frameworks that expect all parameters in one object
+- Grouping query and URL path parameters in one operation parameter model
 
 ---
 

--- a/docs/openapi-options.md
+++ b/docs/openapi-options.md
@@ -29,6 +29,7 @@ Controls which sections of the OpenAPI specification to generate models from.
 | `schemas` | Generate from `#/components/schemas` (default) |
 | `parameters` | Include parameter models for operations selected by `paths` or `webhooks` |
 | `paths` | Generate models from path operation request bodies and responses |
+| `webhooks` | Generate models from webhook operation request bodies and responses |
 
 ### Default behavior (schemas only)
 

--- a/docs/openapi-options.md
+++ b/docs/openapi-options.md
@@ -27,8 +27,8 @@ Controls which sections of the OpenAPI specification to generate models from.
 | Scope | Description |
 |-------|-------------|
 | `schemas` | Generate from `#/components/schemas` (default) |
-| `parameters` | Generate from `#/components/parameters` |
-| `paths` | Generate from path operation parameters |
+| `parameters` | Include parameter models for operations selected by `paths` or `webhooks` |
+| `paths` | Generate models from path operation request bodies and responses |
 
 ### Default behavior (schemas only)
 
@@ -38,41 +38,50 @@ datamodel-codegen --input openapi.yaml --output models.py
 
 Generates models only from `#/components/schemas`.
 
-### Include parameters
+### Include operation schemas
 
 ```bash
 datamodel-codegen --input openapi.yaml --output models.py \
-  --openapi-scopes schemas parameters
+  --openapi-scopes schemas paths
 ```
 
-Also generates models from `#/components/parameters`.
+Also generates models from operation request bodies and responses.
 
-### Include path-level definitions
+### Include operation parameter models
 
 ```bash
 datamodel-codegen --input openapi.yaml --output models.py \
   --openapi-scopes schemas parameters paths
 ```
 
-Generates models from all sources, including inline path operation parameters.
+Also generates a query parameter model for each operation that has query parameters.
+Add `--include-path-parameters` to include URL path parameters in these models.
+Parameters can be declared inline or referenced from `#/components/parameters`.
+Unreferenced entries in `components.parameters` do not generate standalone models,
+and the `parameters` scope alone does not select operations.
 
 ### When to use each scope
 
 | Use Case | Recommended Scopes |
 |----------|-------------------|
 | Basic model generation | `schemas` (default) |
-| Reusable parameter types | `schemas parameters` |
-| Complete API coverage | `schemas parameters paths` |
+| Request and response models | `schemas paths` |
+| Request, response, and query parameter models | `schemas paths parameters` |
 
 ---
 
 ## `--include-path-parameters`
 
-Includes path parameters as fields in generated models.
+Includes path parameters as fields in generated operation parameter models.
+Use this with `--openapi-scopes paths parameters`.
 
 ### OpenAPI Example
 
 ```yaml
+openapi: "3.0.3"
+info:
+  title: Orders API
+  version: "1.0"
 paths:
   /users/{user_id}/orders/{order_id}:
     get:
@@ -80,42 +89,41 @@ paths:
       parameters:
         - name: user_id
           in: path
+          required: true
           schema:
             type: string
         - name: order_id
           in: path
+          required: true
           schema:
             type: integer
+      responses:
+        '204':
+          description: No content
 ```
 
 ### Without `--include-path-parameters`
 
-```python
-class GetOrderResponse(BaseModel):
-    # Only response body fields
-    items: list[Item]
-    total: float
-```
+Only query parameters are included in operation parameter models. This example
+has only path parameters, so it does not generate a parameter model without the flag.
 
 ### With `--include-path-parameters`
 
 ```bash
-datamodel-codegen --input openapi.yaml --output models.py --include-path-parameters
+datamodel-codegen --input openapi.yaml --output models.py \
+  --openapi-scopes paths parameters --include-path-parameters --use-operation-id-as-name
 ```
 
 ```python
-class GetOrderResponse(BaseModel):
+class GetOrderParameters(BaseModel):
     user_id: str
     order_id: int
-    items: list[Item]
-    total: float
 ```
 
 ### When to use
 
 - Building request validation models that include URL parameters
-- Creating unified request/response types for API clients
-- Generating models for frameworks that expect all parameters in one object
+- Grouping query and URL path parameters in one operation parameter model
 
 ---
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -455,8 +455,9 @@ readOnly/writeOnly resolution works with local and file reference types:
 | Feature | Generation behavior |
 |---------|---------------------|
 | `components.schemas` | Default model generation scope |
-| `components.parameters` | Generated with `--openapi-scopes parameters` |
+| `components.parameters` | Resolved when referenced by selected operations; no standalone models for unreferenced entries |
 | `paths` operation schemas | Generated with `--openapi-scopes paths` |
+| Operation query parameters | Included with `--openapi-scopes paths parameters`; add `--include-path-parameters` for URL path parameters |
 | `readOnly` / `writeOnly` | Request/response variants with `--read-only-write-only-model-type` |
 | Discriminators and combined schemas | Converted into Python unions and inheritance-aware models where possible |
 | Local and file `$ref` | Resolved before model generation |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified OpenAPI scope behavior for generating models from operation request bodies, responses, and webhook operations.
  - Updated parameter-scope guidance to explain how parameter models are generated for selected operations.
  - Added examples of operation-level query parameter models with URL path parameters included.
  - Updated guidance for using `--include-path-parameters`.
  - Clarified handling of referenced component parameters and operation parameters in supported OpenAPI features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->