### PR TITLE
Fix msgspec typename inheritance

### DIFF
--- a/src/datamodel_code_generator/parser/graphql.py
+++ b/src/datamodel_code_generator/parser/graphql.py
@@ -564,15 +564,48 @@ class GraphQLParser(Parser["GraphQLParserConfig", "JsonSchemaFeatures"]):
                 field.name for base in bases for field in base.fields if field.alias == "__typename"
             }
             fields = {field.name: field for field in source.fields}
-            if self.data_model_type.REQUIRES_UNIQUE_FIELD_ALIASES and any(
-                field.name in inherited_typename_names and (field.alias is None or field.alias == field.name)
-                for field in source.fields
+            inherited_fields = None
+            if self.data_model_type.REQUIRES_UNIQUE_FIELD_ALIASES and (
+                conflicts := [
+                    field
+                    for field in source.fields
+                    if field.name in inherited_typename_names and (field.alias is None or field.alias == field.name)
+                ]
             ):
-                self._share_typename_slot(schema, obj)
-                return
+                inherited_fields = get_inherited_fields(bases)
+                excludes = {
+                    cast("str", field.name)
+                    for field in (*source.fields, *inherited_fields.values())
+                    if field.alias != "__typename"
+                }
+                for field in conflicts:
+                    wire_name = cast("str", field.name)
+                    fields.pop(wire_name)
+                    inherited = next(
+                        (
+                            candidate
+                            for candidate in inherited_fields.values()
+                            if (candidate.alias or candidate.name) == wire_name
+                        ),
+                        None,
+                    )
+                    field.name = (
+                        inherited.name
+                        if inherited
+                        else self.model_resolver.get_valid_field_name(
+                            wire_name, excludes=excludes, model_type=self.field_name_model_type
+                        )
+                    )
+                    field.alias = wire_name
+                    field.serialization_alias = self.get_serialization_alias(
+                        wire_name, cast("str", field.name), obj.name
+                    )
+                    excludes.add(cast("str", field.name))
+                    fields[field.name] = field
             if not inherited_typename_names.difference(fields):
                 return
-            inherited_fields = get_inherited_fields(bases)
+            if inherited_fields is None:
+                inherited_fields = get_inherited_fields(bases)
             for inherited in inherited_fields.values():
                 if (
                     inherited.alias != "__typename"
@@ -620,36 +653,3 @@ class GraphQLParser(Parser["GraphQLParserConfig", "JsonSchemaFeatures"]):
                 pending.extend(implementations.objects)
                 pending.extend(implementations.interfaces)
             resolve(obj)
-
-    def _share_typename_slot(
-        self,
-        schema: graphql.GraphQLSchema,
-        root: graphql.GraphQLObjectType | graphql.GraphQLInterfaceType,
-    ) -> None:
-        """Share a family slot when a backend cannot retain separate inherited aliases."""
-        pending = [root]
-        visited: set[graphql.GraphQLObjectType | graphql.GraphQLInterfaceType] = set()
-        excludes: set[str] = set()
-        typename_fields: list[tuple[str, DataModelFieldBase]] = []
-        while pending:
-            obj = pending.pop()
-            if obj in visited or obj.name not in self.references:
-                continue
-            visited.add(obj)
-            pending.extend(obj.interfaces)
-            if isinstance(obj, graphql.GraphQLInterfaceType):
-                implementations = schema.get_implementations(obj)
-                pending.extend(implementations.objects)
-                pending.extend(implementations.interfaces)
-            source = cast("DataModel", self.references[obj.name].source)
-            for field in source.fields:
-                if field.alias == "__typename":
-                    typename_fields.append((obj.name, field))
-                else:
-                    excludes.add(cast("str", field.name))
-        field_name = self.model_resolver.get_valid_field_name(
-            "typename__", excludes=excludes, model_type=self.field_name_model_type
-        )
-        for name, field in typename_fields:
-            field.name = field_name
-            field.serialization_alias = self.get_serialization_alias("__typename", field_name, name)

--- a/tests/data/expected/main/graphql/typename_collision_msgspec_Struct_False.py
+++ b/tests/data/expected/main/graphql/typename_collision_msgspec_Struct_False.py
@@ -28,35 +28,33 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 
 class Base(Struct):
     value: Int
-    typename___1: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
+    typename__: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
 
 
 class ZNode(Struct):
     camelValue: Int
     typename__: String
-    typename___2: Literal['ZNode'] | UnsetType = field(
+    typename___1: Literal['ZNode'] | UnsetType = field(
         name='__typename', default='ZNode'
     )
 
 
 class Cross(Base, kw_only=True):
-    typename__: String
+    typename___1: String = field(name='typename__')
     value: Int
-    typename___1: Literal['Cross'] | UnsetType = field(
-        name='__typename', default='Cross'
-    )
+    typename__: Literal['Cross'] | UnsetType = field(name='__typename', default='Cross')
 
 
 class Item(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
 
 
 class Ordinary(Base):
     value: Int
-    typename___1: Literal['Ordinary'] | UnsetType = field(
+    typename__: Literal['Ordinary'] | UnsetType = field(
         name='__typename', default='Ordinary'
     )
 
@@ -64,8 +62,8 @@ class Ordinary(Base):
 class Second(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Second'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Second'] | UnsetType = field(
         name='__typename', default='Second'
     )
 
@@ -93,7 +91,7 @@ Choice: TypeAlias = Union[
 class ANode(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['ANode'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['ANode'] | UnsetType = field(
         name='__typename', default='ANode'
     )

--- a/tests/data/expected/main/graphql/typename_collision_msgspec_Struct_False.txt
+++ b/tests/data/expected/main/graphql/typename_collision_msgspec_Struct_False.txt
@@ -33,7 +33,7 @@
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2"
+        "typename___1"
       ],
       "values": {
         "camelValue": 1,
@@ -43,15 +43,15 @@
       "attributes": {
         "camelValue": 1,
         "typename__": "node",
-        "typename___2": "ZNode"
+        "typename___1": "ZNode"
       }
     },
     "ANode": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 2,
@@ -62,16 +62,16 @@
       "attributes": {
         "camelValue": 2,
         "typename__": "child",
-        "typename___2": "ANode",
-        "typename___1": 12
+        "typename___1": "ANode",
+        "typename___1_1": 12
       }
     },
     "Item": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 3,
@@ -82,16 +82,16 @@
       "attributes": {
         "camelValue": 3,
         "typename__": "item",
-        "typename___2": "Item",
-        "typename___1": 13
+        "typename___1": "Item",
+        "typename___1_1": 13
       }
     },
     "Second": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 4,
@@ -102,14 +102,14 @@
       "attributes": {
         "camelValue": 4,
         "typename__": "second",
-        "typename___2": "Second",
-        "typename___1": 14
+        "typename___1": "Second",
+        "typename___1_1": 14
       }
     },
     "Base": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 5,
@@ -117,14 +117,14 @@
       },
       "attributes": {
         "value": 5,
-        "typename___1": "Base"
+        "typename__": "Base"
       }
     },
     "Cross": {
       "fields": [
         "value",
-        "typename___1",
-        "typename__"
+        "typename__",
+        "typename___1"
       ],
       "values": {
         "value": 6,
@@ -133,8 +133,8 @@
       },
       "attributes": {
         "value": 6,
-        "typename___1": "Cross",
-        "typename__": "cross"
+        "typename__": "Cross",
+        "typename___1": "cross"
       }
     },
     "Solo": {
@@ -174,7 +174,7 @@
     "Ordinary": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 8,
@@ -182,7 +182,7 @@
       },
       "attributes": {
         "value": 8,
-        "typename___1": "Ordinary"
+        "typename__": "Ordinary"
       }
     }
   }

--- a/tests/data/expected/main/graphql/typename_serialization_msgspec_Struct_False.py
+++ b/tests/data/expected/main/graphql/typename_serialization_msgspec_Struct_False.py
@@ -28,35 +28,33 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 
 class Base(Struct):
     value: Int
-    typename___1: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
+    typename__: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
 
 
 class ZNode(Struct):
     camelValue: Int
     typename__: String
-    typename___2: Literal['ZNode'] | UnsetType = field(
+    typename___1: Literal['ZNode'] | UnsetType = field(
         name='__typename', default='ZNode'
     )
 
 
 class Cross(Base, kw_only=True):
-    typename__: String = field(name='typename__')
+    typename___1: String = field(name='typename__')
     value: Int
-    typename___1: Literal['Cross'] | UnsetType = field(
-        name='__typename', default='Cross'
-    )
+    typename__: Literal['Cross'] | UnsetType = field(name='__typename', default='Cross')
 
 
 class Item(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
 
 
 class Ordinary(Base):
     value: Int
-    typename___1: Literal['Ordinary'] | UnsetType = field(
+    typename__: Literal['Ordinary'] | UnsetType = field(
         name='__typename', default='Ordinary'
     )
 
@@ -64,8 +62,8 @@ class Ordinary(Base):
 class Second(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Second'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Second'] | UnsetType = field(
         name='__typename', default='Second'
     )
 
@@ -93,7 +91,7 @@ Choice: TypeAlias = Union[
 class ANode(ZNode, kw_only=True):
     camelValue: Int
     typename__: String
-    typename___1: Int
-    typename___2: Literal['ANode'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['ANode'] | UnsetType = field(
         name='__typename', default='ANode'
     )

--- a/tests/data/expected/main/graphql/typename_serialization_msgspec_Struct_False.txt
+++ b/tests/data/expected/main/graphql/typename_serialization_msgspec_Struct_False.txt
@@ -33,7 +33,7 @@
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2"
+        "typename___1"
       ],
       "values": {
         "camelValue": 1,
@@ -43,15 +43,15 @@
       "attributes": {
         "camelValue": 1,
         "typename__": "node",
-        "typename___2": "ZNode"
+        "typename___1": "ZNode"
       }
     },
     "ANode": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 2,
@@ -62,16 +62,16 @@
       "attributes": {
         "camelValue": 2,
         "typename__": "child",
-        "typename___2": "ANode",
-        "typename___1": 12
+        "typename___1": "ANode",
+        "typename___1_1": 12
       }
     },
     "Item": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 3,
@@ -82,16 +82,16 @@
       "attributes": {
         "camelValue": 3,
         "typename__": "item",
-        "typename___2": "Item",
-        "typename___1": 13
+        "typename___1": "Item",
+        "typename___1_1": 13
       }
     },
     "Second": {
       "fields": [
         "camelValue",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 4,
@@ -102,14 +102,14 @@
       "attributes": {
         "camelValue": 4,
         "typename__": "second",
-        "typename___2": "Second",
-        "typename___1": 14
+        "typename___1": "Second",
+        "typename___1_1": 14
       }
     },
     "Base": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 5,
@@ -117,14 +117,14 @@
       },
       "attributes": {
         "value": 5,
-        "typename___1": "Base"
+        "typename__": "Base"
       }
     },
     "Cross": {
       "fields": [
         "value",
-        "typename___1",
-        "typename__"
+        "typename__",
+        "typename___1"
       ],
       "values": {
         "value": 6,
@@ -133,8 +133,8 @@
       },
       "attributes": {
         "value": 6,
-        "typename___1": "Cross",
-        "typename__": "cross"
+        "typename__": "Cross",
+        "typename___1": "cross"
       }
     },
     "Solo": {
@@ -174,7 +174,7 @@
     "Ordinary": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 8,
@@ -182,7 +182,7 @@
       },
       "attributes": {
         "value": 8,
-        "typename___1": "Ordinary"
+        "typename__": "Ordinary"
       }
     }
   }

--- a/tests/data/expected/main/graphql/typename_snake_msgspec_Struct_False.py
+++ b/tests/data/expected/main/graphql/typename_snake_msgspec_Struct_False.py
@@ -28,35 +28,33 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 
 class Base(Struct):
     value: Int
-    typename___1: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
+    typename__: Literal['Base'] | UnsetType = field(name='__typename', default='Base')
 
 
 class ZNode(Struct):
     camel_value: Int = field(name='camelValue')
     typename__: String
-    typename___2: Literal['ZNode'] | UnsetType = field(
+    typename___1: Literal['ZNode'] | UnsetType = field(
         name='__typename', default='ZNode'
     )
 
 
 class Cross(Base, kw_only=True):
-    typename__: String
+    typename___1: String = field(name='typename__')
     value: Int
-    typename___1: Literal['Cross'] | UnsetType = field(
-        name='__typename', default='Cross'
-    )
+    typename__: Literal['Cross'] | UnsetType = field(name='__typename', default='Cross')
 
 
 class Item(ZNode, kw_only=True):
     camel_value: Int = field(name='camelValue')
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Item'] | UnsetType = field(name='__typename', default='Item')
 
 
 class Ordinary(Base):
     value: Int
-    typename___1: Literal['Ordinary'] | UnsetType = field(
+    typename__: Literal['Ordinary'] | UnsetType = field(
         name='__typename', default='Ordinary'
     )
 
@@ -64,8 +62,8 @@ class Ordinary(Base):
 class Second(ZNode, kw_only=True):
     camel_value: Int = field(name='camelValue')
     typename__: String
-    typename___1: Int
-    typename___2: Literal['Second'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['Second'] | UnsetType = field(
         name='__typename', default='Second'
     )
 
@@ -93,7 +91,7 @@ Choice: TypeAlias = Union[
 class ANode(ZNode, kw_only=True):
     camel_value: Int = field(name='camelValue')
     typename__: String
-    typename___1: Int
-    typename___2: Literal['ANode'] | UnsetType = field(
+    typename___1_1: Int = field(name='typename___1')
+    typename___1: Literal['ANode'] | UnsetType = field(
         name='__typename', default='ANode'
     )

--- a/tests/data/expected/main/graphql/typename_snake_msgspec_Struct_False.txt
+++ b/tests/data/expected/main/graphql/typename_snake_msgspec_Struct_False.txt
@@ -33,7 +33,7 @@
       "fields": [
         "camel_value",
         "typename__",
-        "typename___2"
+        "typename___1"
       ],
       "values": {
         "camelValue": 1,
@@ -43,15 +43,15 @@
       "attributes": {
         "camel_value": 1,
         "typename__": "node",
-        "typename___2": "ZNode"
+        "typename___1": "ZNode"
       }
     },
     "ANode": {
       "fields": [
         "camel_value",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 2,
@@ -62,16 +62,16 @@
       "attributes": {
         "camel_value": 2,
         "typename__": "child",
-        "typename___2": "ANode",
-        "typename___1": 12
+        "typename___1": "ANode",
+        "typename___1_1": 12
       }
     },
     "Item": {
       "fields": [
         "camel_value",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 3,
@@ -82,16 +82,16 @@
       "attributes": {
         "camel_value": 3,
         "typename__": "item",
-        "typename___2": "Item",
-        "typename___1": 13
+        "typename___1": "Item",
+        "typename___1_1": 13
       }
     },
     "Second": {
       "fields": [
         "camel_value",
         "typename__",
-        "typename___2",
-        "typename___1"
+        "typename___1",
+        "typename___1_1"
       ],
       "values": {
         "camelValue": 4,
@@ -102,14 +102,14 @@
       "attributes": {
         "camel_value": 4,
         "typename__": "second",
-        "typename___2": "Second",
-        "typename___1": 14
+        "typename___1": "Second",
+        "typename___1_1": 14
       }
     },
     "Base": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 5,
@@ -117,14 +117,14 @@
       },
       "attributes": {
         "value": 5,
-        "typename___1": "Base"
+        "typename__": "Base"
       }
     },
     "Cross": {
       "fields": [
         "value",
-        "typename___1",
-        "typename__"
+        "typename__",
+        "typename___1"
       ],
       "values": {
         "value": 6,
@@ -133,8 +133,8 @@
       },
       "attributes": {
         "value": 6,
-        "typename___1": "Cross",
-        "typename__": "cross"
+        "typename__": "Cross",
+        "typename___1": "cross"
       }
     },
     "Solo": {
@@ -174,7 +174,7 @@
     "Ordinary": {
       "fields": [
         "value",
-        "typename___1"
+        "typename__"
       ],
       "values": {
         "value": 8,
@@ -182,7 +182,7 @@
       },
       "attributes": {
         "value": 8,
-        "typename___1": "Ordinary"
+        "typename__": "Ordinary"
       }
     }
   }

--- a/tests/main/graphql/test_typename_collisions.py
+++ b/tests/main/graphql/test_typename_collisions.py
@@ -43,7 +43,7 @@ def _has_literal(annotation: object) -> bool:
 def test_graphql_typename_collisions(
     entrypoint: str, output_model_type: DataModelType, profile: str, no_typename: bool, output_file: Path
 ) -> None:
-    """Retain local typename attributes, including the older msgspec identity-alias boundary."""
+    """Retain local typename attributes and inherited aliases across backends."""
     settings = json.loads((DATA_PATH / "payloads/typename_collision_settings.json").read_text())[profile]
     payload = json.loads((DATA_PATH / "payloads" / f"typename_collision_{profile}.json").read_text())
     input_path = GRAPHQL_DATA_PATH / settings.pop("schema")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GraphQL model generation when `__typename` conflicts with inherited or existing fields.
  - Generated model attributes now receive consistent unique names while preserving their original GraphQL field mappings and serialization behavior.
  - Updated discriminator fields across supported model backends for more predictable naming.

- **Tests**
  - Expanded coverage for typename collisions, inherited aliases, and preservation of local typename attributes across backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->